### PR TITLE
feat(build): Support -t and use python:3.8 as base image

### DIFF
--- a/pkg/lang/ir/stmt.go
+++ b/pkg/lang/ir/stmt.go
@@ -15,15 +15,13 @@
 package ir
 
 import (
-	"fmt"
-
 	"github.com/moby/buildkit/client/llb"
 )
 
 var Stmt llb.State
 
 func BaseStmt(os, language string) {
-	base := llb.Image(fmt.Sprintf("docker.io/library/%s:%s", language, os))
-	run := base.Run(llb.Shlex("ls -la"))
-	Stmt = run.State
+	// TODO(gaocegege): Support multi os and languages.
+	base := llb.Image("docker.io/library/python:3.8")
+	Stmt = base
 }


### PR DESCRIPTION
You can create the dir /tmp/buildkit first, then run the command `midi b` to create the tar, then run `docker load -i /tmp/buildkit/test.tar` to load them into the docker daemon to debug.

Fix #20 

Ref #25 

Signed-off-by: Ce Gao <ce.gao@outlook.com>