### PR TITLE
feat(CLI): Support per-user config

### DIFF
--- a/build.MIDI
+++ b/build.MIDI
@@ -9,8 +9,3 @@ install_package(name = [
     "gcc"
 ])
 cuda(version="11.2", cudnn="8")
-
-vscode(plugins = [
-    "ms-vscode.cpptools-1.7.1",
-    "github.copilot-1.12.5517"
-])

--- a/pkg/flag/consts.go
+++ b/pkg/flag/consts.go
@@ -17,4 +17,5 @@ package flag
 const (
 	FlagCacheDir   = "cache-dir"
 	FlagContextDir = "context-dir"
+	FlagConfig     = "config"
 )

--- a/pkg/lang/frontend/starlark/interpreter.go
+++ b/pkg/lang/frontend/starlark/interpreter.go
@@ -44,6 +44,7 @@ func NewInterpreter() Interpreter {
 }
 
 func (s generalInterpreter) ExecFile(filename string) (interface{}, error) {
+	logrus.WithField("filename", filename).Debug("inperprete the file")
 	var src interface{}
 	globals, err := starlark.ExecFile(s.Thread, filename, src, nil)
 	if err != nil {


### PR DESCRIPTION
A config file `~/.midi/config.MIDI` is introduced

```py
vscode(plugins = [
    "ms-vscode.cpptools-1.7.1",
    "github.copilot-1.12.5517"
])
```

You can define some MIDI statements and it works for all environments

Fix #22 

Signed-off-by: Ce Gao <cegao@tensorchord.ai>