### PR TITLE
feat(CLI): Support bootstrap command

### DIFF
--- a/cmd/midi/bootstrap.go
+++ b/cmd/midi/bootstrap.go
@@ -1,0 +1,229 @@
+// Copyright 2022 The MIDI Authors
+// Copyright 2022 The midi Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/containerd/containerd/log"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	cli "github.com/urfave/cli/v2"
+
+	"github.com/tensorchord/MIDI/pkg/buildkitd"
+	"github.com/tensorchord/MIDI/pkg/util/fileutil"
+)
+
+var CommandBootstrap = &cli.Command{
+	Name:  "bootstrap",
+	Usage: "Bootstraps midi installation including shell autocompletion and buildkit image download",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "buildkit",
+			Usage:   "Download the image and bootstrap buildkit",
+			Aliases: []string{"b"},
+			Value:   true,
+		},
+		&cli.BoolFlag{
+			Name:  "with-autocomplete",
+			Usage: "Add midi autocompletions",
+			Value: true,
+		},
+	},
+
+	Action: bootstrap,
+}
+
+func bootstrap(clicontext *cli.Context) error {
+	autocomplete := clicontext.Bool("with-autocomplete")
+	if autocomplete {
+		// Because this requires sudo, it should warn and not fail the rest of it.
+		err := insertBashCompleteEntry()
+		if err != nil {
+			logrus.Warnf("Warning: %s\n", err.Error())
+			err = nil
+		}
+		err = insertZSHCompleteEntry()
+		if err != nil {
+			logrus.Warnf("Warning: %s\n", err.Error())
+			err = nil
+		}
+
+		logrus.Info("You may have to restart your shell for autocomplete to get initialized (e.g. run \"exec $SHELL\")\n")
+	}
+
+	buildkit := clicontext.Bool("buildkit")
+
+	if buildkit {
+		bkClient := buildkitd.NewClient()
+		err := bkClient.Bootstrap(clicontext.Context)
+		if err != nil {
+			return errors.Wrap(err, "failed to bootstrap buildkit")
+		}
+	}
+	return nil
+}
+
+// If debugging this, it might be required to run `rm ~/.zcompdump*` to remove the cache
+func insertZSHCompleteEntry() error {
+	// should be the same on linux and macOS
+	path := "/usr/local/share/zsh/site-functions/_midi"
+	dirPath := filepath.Dir(path)
+
+	dirPathExists, err := fileutil.DirExists(dirPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if %s exists", dirPath)
+	}
+	if !dirPathExists {
+		log.L.Warn("Warning: unable to enable zsh-completion: %s does not exist\n", dirPath)
+		return nil // zsh-completion isn't available, silently fail.
+	}
+
+	pathExists, err := fileutil.FileExists(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed to check if %s exists", path)
+	}
+	if pathExists {
+		return nil // file already exists, don't update it.
+	}
+
+	// create the completion file
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	compEntry, err := zshCompleteEntry()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: unable to enable zsh-completion: %s\n", err)
+		return nil // zsh-completion isn't available, silently fail.
+	}
+
+	_, err = f.Write([]byte(compEntry))
+	if err != nil {
+		return errors.Wrapf(err, "failed writing to %s", path)
+	}
+
+	return deleteZcompdump()
+}
+
+func zshCompleteEntry() (string, error) {
+	template := `#compdef _midi midi
+
+function _midi {
+    autoload -Uz bashcompinit
+    bashcompinit
+    complete -o nospace -C '__midi__' midi
+}
+`
+	return renderEntryTemplate(template)
+}
+
+func insertBashCompleteEntry() error {
+	var path string
+	if runtime.GOOS == "darwin" {
+		path = "/usr/local/etc/bash_completion.d/midi"
+	} else {
+		path = "/usr/share/bash-completion/completions/midi"
+	}
+	dirPath := filepath.Dir(path)
+
+	dirPathExists, err := fileutil.DirExists(dirPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed checking if %s exists", dirPath)
+	}
+	if !dirPathExists {
+		fmt.Fprintf(os.Stderr, "Warning: unable to enable bash-completion: %s does not exist\n", dirPath)
+		return nil // bash-completion isn't available, silently fail.
+	}
+
+	pathExists, err := fileutil.FileExists(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed checking if %s exists", path)
+	}
+	if pathExists {
+		return nil // file already exists, don't update it.
+	}
+
+	// create the completion file
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	bashEntry, err := bashCompleteEntry()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: unable to enable bash-completion: %s\n", err)
+		return nil // bash-completion isn't available, silently fail.
+	}
+
+	_, err = f.Write([]byte(bashEntry))
+	if err != nil {
+		return errors.Wrapf(err, "failed writing to %s", path)
+	}
+	return nil
+}
+
+func bashCompleteEntry() (string, error) {
+	template := "complete -o nospace -C '__midi__' midi\n"
+	return renderEntryTemplate(template)
+}
+
+func renderEntryTemplate(template string) (string, error) {
+	midiPath, err := os.Executable()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to determine midi path: %s", err)
+	}
+	return strings.ReplaceAll(template, "__midi__", midiPath), nil
+}
+
+func deleteZcompdump() error {
+	var homeDir string
+	sudoUser, found := os.LookupEnv("SUDO_USER")
+	if !found {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			return errors.Wrapf(err, "failed to lookup current user home dir")
+		}
+	} else {
+		currentUser, err := user.Lookup(sudoUser)
+		if err != nil {
+			return errors.Wrapf(err, "failed to lookup user %s", sudoUser)
+		}
+		homeDir = currentUser.HomeDir
+	}
+	files, err := os.ReadDir(homeDir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to read dir %s", homeDir)
+	}
+	for _, f := range files {
+		if strings.HasPrefix(f.Name(), ".zcompdump") {
+			path := filepath.Join(homeDir, f.Name())
+			err := os.Remove(path)
+			if err != nil {
+				return errors.Wrapf(err, "failed to remove %s", path)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/midi/build.go
+++ b/cmd/midi/build.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/cockroachdb/errors"
@@ -26,10 +27,9 @@ import (
 )
 
 var CommandBuild = &cli.Command{
-	Name:      "build",
-	Aliases:   []string{"b"},
-	Usage:     "build MIDI environment",
-	UsageText: `TODO`,
+	Name:    "build",
+	Aliases: []string{"b"},
+	Usage:   "build MIDI environment",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "tag",
@@ -67,6 +67,8 @@ func build(clicontext *cli.Context) error {
 
 	tag := clicontext.String("tag")
 
-	builder := builder.New("unix:///run/buildkit/buildkitd.sock", config, path, tag)
+	builder := builder.New(
+		fmt.Sprintf("docker-container://%s", viper.GetString(flag.FlagBuildkitdContainer)),
+		config, path, tag)
 	return builder.Build(clicontext.Context)
 }

--- a/cmd/midi/up.go
+++ b/cmd/midi/up.go
@@ -29,10 +29,9 @@ import (
 )
 
 var CommandUp = &cli.Command{
-	Name:      "up",
-	Aliases:   []string{"u"},
-	Usage:     "build and run the MIDI environment",
-	UsageText: `TODO`,
+	Name:    "up",
+	Aliases: []string{"u"},
+	Usage:   "build and run the MIDI environment",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "tag",
@@ -86,7 +85,7 @@ func up(clicontext *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	containerID, containerIP, err := dockerClient.Start(clicontext.Context, tag, "midi", gpu)
+	containerID, containerIP, err := dockerClient.StartMIDI(clicontext.Context, tag, "midi", gpu)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/alessio/shellescape v1.4.1
 	github.com/cockroachdb/errors v1.9.0
+	github.com/containerd/containerd v1.6.3-0.20220401172941-5ff8fce1fcc6
 	github.com/creack/pty v1.1.18
 	github.com/docker/docker v20.10.7+incompatible
 	github.com/fatih/color v1.13.0
@@ -32,10 +33,10 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20211118104740-dabe8e521a4f // indirect
 	github.com/cockroachdb/redact v1.1.3 // indirect
 	github.com/containerd/console v1.0.3 // indirect
-	github.com/containerd/containerd v1.6.3-0.20220401172941-5ff8fce1fcc6 // indirect
 	github.com/containerd/continuity v0.2.3-0.20220330195504-d132b287edc8 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/docker/cli v20.10.13+incompatible // indirect
 	github.com/docker/distribution v2.8.0+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6ps
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/cli v20.10.13+incompatible h1:o/STAn7e+b/pQ6keReGRoewVmAgXUkZAMQ8st4vHdKg=
+github.com/docker/cli v20.10.13+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.0+incompatible h1:l9EaZDICImO1ngI+uTifW+ZYvvz7fKISBAKpg+MbWbY=
 github.com/docker/distribution v2.8.0+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v20.10.3-0.20220224222438-c78f6963a1c0+incompatible h1:Ptj2To+ezU/mCBUKdYXBQ2r3/2EJojAlOZrsgprF+is=

--- a/pkg/buildkitd/buildkitd.go
+++ b/pkg/buildkitd/buildkitd.go
@@ -1,0 +1,59 @@
+package buildkitd
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/tensorchord/MIDI/pkg/docker"
+	"github.com/tensorchord/MIDI/pkg/flag"
+)
+
+type Client interface {
+	Bootstrap(ctx context.Context) error
+}
+
+type generalClient struct {
+	containerName string
+	image         string
+}
+
+func NewClient() Client {
+	return &generalClient{
+		containerName: viper.GetString(flag.FlagBuildkitdContainer),
+		image:         viper.GetString(flag.FlagBuildkitdImage),
+	}
+}
+
+func (c generalClient) Bootstrap(ctx context.Context) error {
+	_, err := c.MaybeStart(ctx, time.Second*1000)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// MaybeStart ensures that the buildkitd daemon is started. It returns the URL
+// that can be used to connect to it.
+func (c generalClient) MaybeStart(
+	ctx context.Context, runningTimeout time.Duration) (*string, error) {
+	dockerClient, err := docker.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	created, err := dockerClient.IsCreated(ctx, c.containerName)
+	if err != nil {
+		return nil, err
+	}
+
+	if !created {
+		if _, err := dockerClient.StartBuildkitd(ctx, c.image, c.containerName); err != nil {
+			return nil, err
+		}
+		if err := dockerClient.WaitUntilRunning(ctx, c.containerName, runningTimeout); err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}

--- a/pkg/flag/consts.go
+++ b/pkg/flag/consts.go
@@ -15,7 +15,9 @@
 package flag
 
 const (
-	FlagCacheDir   = "cache-dir"
-	FlagContextDir = "context-dir"
-	FlagConfig     = "config"
+	FlagCacheDir           = "cache-dir"
+	FlagContextDir         = "context-dir"
+	FlagConfig             = "config"
+	FlagBuildkitdImage     = "buildkitd-image"
+	FlagBuildkitdContainer = "buildkitd-container-name"
 )

--- a/pkg/util/.editorconfig
+++ b/pkg/util/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = true

--- a/pkg/util/fileutil/file.go
+++ b/pkg/util/fileutil/file.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The earthly Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fileutil
+
+import (
+	"os"
+
+	"github.com/cockroachdb/errors"
+)
+
+// FileExists returns true if the file exists
+func FileExists(filename string) (bool, error) {
+	info, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "unable to stat %s", filename)
+	}
+	return !info.IsDir(), nil
+}
+
+// DirExists returns true if the directory exists
+func DirExists(filename string) (bool, error) {
+	info, err := os.Stat(filename)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "unable to stat %s", filename)
+	}
+	return info.IsDir(), nil
+}


### PR DESCRIPTION
```
NAME:
   midi bootstrap - Bootstraps midi installation including shell autocompletion and buildkit image download

USAGE:
   midi bootstrap [command options] [arguments...]

OPTIONS:
   --buildkit, -b       Download the image and bootstrap buildkit (default: true)
   --with-autocomplete  Add midi autocompletions (default: true)
   --help, -h           show help (default: false)
```

It pulls the buildkitd image and run it in the contaner. Then we do not need to run the buildkitd process locally.

Fix #28 