### PR TITLE
feat(lang): Support command exec without order

### DIFF
--- a/pkg/lang/frontend/starlark/const.go
+++ b/pkg/lang/frontend/starlark/const.go
@@ -24,4 +24,5 @@ const (
 	rulePyPIMirror    = "pip_mirror"
 	ruleShell         = "shell"
 	ruleJupyter       = "jupyter"
+	ruleRun           = "run"
 )

--- a/pkg/lang/frontend/starlark/rules.go
+++ b/pkg/lang/frontend/starlark/rules.go
@@ -39,7 +39,7 @@ func registerMIDIRules() {
 	starlark.Universe[rulePyPIMirror] = starlark.NewBuiltin(rulePyPIMirror, ruleFuncPyPIMirror)
 	starlark.Universe[ruleShell] = starlark.NewBuiltin(ruleShell, ruleFuncShell)
 	starlark.Universe[ruleJupyter] = starlark.NewBuiltin(ruleJupyter, ruleFuncJupyter)
-
+	starlark.Universe[ruleRun] = starlark.NewBuiltin(ruleRun, ruleFuncRun)
 }
 
 func ruleFuncBase(thread *starlark.Thread, _ *starlark.Builtin,
@@ -259,6 +259,28 @@ func ruleFuncJupyter(thread *starlark.Thread, _ *starlark.Builtin,
 	if err := ir.Jupyter(pwdStr, portInt); err != nil {
 		return nil, err
 	}
+
+	return starlark.None, nil
+}
+
+func ruleFuncRun(thread *starlark.Thread, _ *starlark.Builtin,
+	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var commands *starlark.List
+
+	if err := starlark.UnpackArgs(rulePyPIPackage,
+		args, kwargs, "commands?", &commands); err != nil {
+		return nil, err
+	}
+
+	goCommands := []string{}
+	if commands != nil {
+		for i := 0; i < commands.Len(); i++ {
+			goCommands = append(goCommands, commands.Index(i).(starlark.String).GoString())
+		}
+	}
+
+	logger.Debugf("rule `%s` is invoked, commands=%v", ruleRun, goCommands)
+	ir.Run(goCommands)
 
 	return starlark.None, nil
 }

--- a/pkg/lang/ir/interface.go
+++ b/pkg/lang/ir/interface.go
@@ -76,3 +76,9 @@ func Jupyter(pwd string, port int64) error {
 	}
 	return nil
 }
+
+func Run(commands []string) error {
+	// TODO(gaocegege): Support order-based exec.
+	DefaultGraph.Exec = commands
+	return nil
+}

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -15,8 +15,6 @@
 package ir
 
 import (
-	"github.com/moby/buildkit/client/llb"
-
 	"github.com/tensorchord/MIDI/pkg/vscode"
 )
 
@@ -37,7 +35,7 @@ type Graph struct {
 	SystemPackages        []string
 	VSCodePlugins         []vscode.Plugin
 
-	Exec []llb.State
+	Exec []string
 	*JupyterConfig
 }
 


### PR DESCRIPTION
```python
run(commands = ["ls -l", "ls -l"]
```

Ref https://github.com/tensorchord/MIDI/issues/38

We do not support order now. We need to support it soon. Thus we should not close the issue #38

Signed-off-by: Ce Gao <cegao@tensorchord.ai>
