### PR TITLE
fix(docker): Negotiate api version with server

### DIFF
--- a/cmd/midi/destroy.go
+++ b/cmd/midi/destroy.go
@@ -32,7 +32,7 @@ var CommandDestroy = &cli.Command{
 }
 
 func destroy(clicontext *cli.Context) error {
-	dockerClient, err := docker.NewClient()
+	dockerClient, err := docker.NewClient(clicontext.Context)
 	if err != nil {
 		return err
 	}

--- a/cmd/midi/up.go
+++ b/cmd/midi/up.go
@@ -95,7 +95,7 @@ func up(clicontext *cli.Context) error {
 	}
 	gpu := builder.GPUEnabled()
 
-	dockerClient, err := docker.NewClient()
+	dockerClient, err := docker.NewClient(clicontext.Context)
 	if err != nil {
 		return err
 	}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -150,7 +150,7 @@ func (b generalBuilder) Build(ctx context.Context) error {
 	// Load the image to docker host.
 	eg.Go(func() error {
 		defer pipeR.Close()
-		dockerClient, err := docker.NewClient()
+		dockerClient, err := docker.NewClient(ctx)
 		if err != nil {
 			return errors.Wrap(err, "failed to new docker client")
 		}

--- a/pkg/buildkitd/buildkitd.go
+++ b/pkg/buildkitd/buildkitd.go
@@ -89,7 +89,7 @@ func (c generalClient) Close() error {
 // that can be used to connect to it.
 func (c *generalClient) maybeStart(ctx context.Context,
 	runningTimeout, connectingTimeout time.Duration) (string, error) {
-	dockerClient, err := docker.NewClient()
+	dockerClient, err := docker.NewClient(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -57,11 +57,12 @@ type generalClient struct {
 	*client.Client
 }
 
-func NewClient() (Client, error) {
+func NewClient(ctx context.Context) (Client, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
 		return nil, err
 	}
+	cli.NegotiateAPIVersion(ctx)
 	return generalClient{cli}, nil
 }
 


### PR DESCRIPTION
Fix https://github.com/tensorchord/MIDI/issues/29

Docker client can negotiate with server about api version. Thus we do not need to set the env var in the future

Signed-off-by: Ce Gao <cegao@tensorchord.ai>
