### PR TITLE
chore(make) golangci-lint install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ lint: $(GOLANGCI_LINT)
 	@$(GOLANGCI_LINT) run
 
 $(GOLANGCI_LINT):
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(BIN_DIR) v1.23.6
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
 
 mockgen-install:
 	go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
ref to: https://golangci-lint.run/usage/install/#local-installation

Previous there are some errors:

```console
❯ make lint                                                                                                                                        
curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /usr/local/go/bin v1.23.6
golangci/golangci-lint info checking GitHub for tag 'v1.23.6'
golangci/golangci-lint info found version: 1.23.6 for v1.23.6/linux/amd64
golangci/golangci-lint info installed /usr/local/go/bin/golangci-lint
golangci/golangci-lint err this script is deprecated, please do not use it anymore. check https://github.com/goreleaser/godownloader/issues/207
WARN [runner] Can't run linter goanalysis_metalinter: assign: failed prerequisites: inspect@github.com/tensorchord/envd/pkg/unzip 
ERRO Running error: assign: failed prerequisites: inspect@github.com/tensorchord/envd/pkg/unzip 
make: *** [Makefile:102: lint] Error 3
```

Not sure if we need to fix the version to v1.23.6.