### PR TITLE
ci: Avoid duplicate builds on branches and PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
See https://github.com/tensorchord/envd/pull/189 for an example, we have duplicate builds for both branches and PRs. This change would avoid that.