### PR TITLE
fix(Makefile): use `$$` to represent `$` for shell command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ lint: $(GOLANGCI_LINT)
 	@$(GOLANGCI_LINT) run
 
 $(GOLANGCI_LINT):
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
 
 mockgen-install:
 	go install github.com/golang/mock/mockgen@v1.6.0


### PR DESCRIPTION
Signed-off-by: Triple-Z <me@triplez.cn>

fixes #195 