### PR TITLE
ci: Cancel redundant concurrent builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: lint


### PR DESCRIPTION
Changing reviewers would trigger multiple builds as observed in https://github.com/tensorchord/envd/pull/251. Concurrent builds also occur when you push multiple commits sequentially to a PR.

We should cancel the concurrent builds to avoid waste of resources.

<img width="1006" alt="Screen Shot 2022-06-09 at 12 12 00 AM" src="https://user-images.githubusercontent.com/4269898/172762588-ced93bba-4eda-4c7f-8e43-8b7f440ca38e.png">


Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>