### PR TITLE
fix: py27 subprocess

### DIFF
--- a/envd/cmd.py
+++ b/envd/cmd.py
@@ -19,4 +19,4 @@ from pkg_resources import resource_filename
 
 def envd():
     path = resource_filename("envd", "bin/envd")
-    subprocess.run([path] + sys.argv[1:])
+    subprocess.check_call([path] + sys.argv[1:])


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

https://docs.python.org/3/library/subprocess.html#older-high-level-api

`subprocess.run` is added from 3.5 and became the recommended method.

To support py27, we should change to `check_call`.