### PR TITLE
fix: add api/__init__.py

### DIFF
--- a/envd/api/__init__.py
+++ b/envd/api/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2022 The envd Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

Lacking this file will trigger the warning:

```
/python3.8/site-packages/setuptools/command/build_py.py:153: SetuptoolsDeprecationWarning:     Installing 'envd.api' as data is deprecated, please list it in `packages`.
    !!


    ############################
    # Package would be ignored #
    ############################
    Python recognizes 'envd.api' as an importable package,
    but it is not listed in the `packages` configuration of setuptools.

    'envd.api' has been automatically added to the distribution only
    because it may contain data files, but this behavior is likely to change
    in future versions of setuptools (and therefore is considered deprecated).

    Please make sure that 'envd.api' is included as a package by using
    the `packages` configuration field or the proper discovery methods
    (for example by using `find_namespace_packages(...)`/`find_namespace:`
    instead of `find_packages(...)`/`find:`).

    You can read more about "package discovery" and "data files" on setuptools
    documentation page.


!!

  check.warn(importable)
```