### PR TITLE
fix: Disable unit test in macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,7 +62,7 @@ jobs:
     name: test
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
       GOPATH: ${{ github.workspace }}/go


### PR DESCRIPTION
https://github.community/t/why-is-docker-not-installed-on-macos/17017/7

Docker cannot be installed in GitHub macOS runners. Thus we disable the unit test for macOS. We just build the binary.

Signed-off-by: Ce Gao <cegao@tensorchord.ai>