### PR TITLE
fix: use python3 explicitly to avoid type hints error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         CIBW_ARCHS: auto64
     - name: Build source distribution
       run: |
-        python setup.py sdist
+        python3 setup.py sdist
         mv dist/*.tar.gz wheelhouse/
     - name: Upload to PyPI    
       env:


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

* close #376 