### PR TITLE
feat(cli): support `envd build --output`

### DIFF
--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -57,6 +57,12 @@ var CommandBuild = &cli.Command{
 			Aliases: []string{"pubk"},
 			Value:   sshconfig.GetPublicKey(),
 		},
+		&cli.PathFlag{
+			Name:    "output",
+			Usage:   "Output destination (format: type=tar,dest=path)",
+			Aliases: []string{"o"},
+			Value:   "",
+		},
 	},
 
 	Action: build,
@@ -94,7 +100,7 @@ func build(clicontext *cli.Context) error {
 	})
 	logger.Debug("starting build command")
 
-	builder, err := builder.New(clicontext.Context, config, manifest, buildContext, tag)
+	builder, err := builder.New(clicontext.Context, config, manifest, buildContext, tag, clicontext.Path("output"))
 	if err != nil {
 		return errors.Wrap(err, "failed to create the builder")
 	}

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -135,7 +135,7 @@ func up(clicontext *cli.Context) error {
 	})
 	logger.Debug("starting up command")
 
-	builder, err := builder.New(clicontext.Context, config, manifest, buildContext, tag)
+	builder, err := builder.New(clicontext.Context, config, manifest, buildContext, tag, "")
 	if err != nil {
 		return errors.Wrap(err, "failed to create the builder")
 	}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Builder", func() {
 			buildkitdSocket = "wrong"
 			viper.Set(flag.FlagBuildkitdContainer, buildkitdSocket)
 			It("should return an error", func() {
-				_, err := New(context.TODO(), configFilePath, manifestFilePath, buildContext, tag)
+				_, err := New(context.TODO(), configFilePath, manifestFilePath, buildContext, tag, "")
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/pkg/builder/util_test.go
+++ b/pkg/builder/util_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package builder
+
+import "testing"
+
+func Test_parseOutput(t *testing.T) {
+	type args struct {
+		output string
+	}
+
+	tests := []struct {
+		name       string
+		args       args
+		outputType string
+		outputDest string
+		wantErr    bool
+	}{{
+		"parsing output successfully",
+		args{
+			output: "type=tar,dest=test.tar",
+		},
+		"tar",
+		"test.tar",
+		false,
+	}, {
+		"output without type",
+		args{
+			output: "type=,dest=test.tar",
+		},
+		"",
+		"",
+		true,
+	}, {
+		"output without dest",
+		args{
+			output: "type=tar,dest=",
+		},
+		"",
+		"",
+		true,
+	}, {
+		"no output",
+		args{
+			output: "",
+		},
+		"",
+		"",
+		false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := parseOutput(tt.args.output)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseOutput() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.outputType {
+				t.Errorf("parseOutput() outputType = %v, want %v", got, tt.outputType)
+			}
+			if got1 != tt.outputDest {
+				t.Errorf("parseOutput() outputDest = %v, want %v", got1, tt.outputDest)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Yuchen Cheng <rudeigerc@gmail.com>

Closes #272 

```shell
$ envd build --output type=tar,dest=test.tar
```

The parameters follow `docker build --output`.

References:
- https://docs.docker.com/engine/reference/commandline/build/#options