### PR TITLE
docs: Fix incorrect link to documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 ## Documentation
 
-See [envd documentation](https://envd.tensorchord.ai/docs/intro).
+See [envd documentation](https://envd.tensorchord.ai/).


### PR DESCRIPTION
Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>