### PR TITLE
fix: Only configure conda for Python environment

### DIFF
--- a/pkg/lang/ir/system.go
+++ b/pkg/lang/ir/system.go
@@ -119,9 +119,11 @@ func (g *Graph) compileBase() llb.State {
 		Run(llb.Shlex("adduser envd sudo"),
 			llb.WithCustomName("[internal] add user envd to sudoers")).
 		Run(llb.Shlex("chown -R envd:envd /usr/local/lib"),
-			llb.WithCustomName("[internal] configure user permissions")).
-		Run(llb.Shlex("chown -R envd:envd /opt/conda"),
 			llb.WithCustomName("[internal] configure user permissions"))
+	if g.Language.Name == "python" {
+		res = res.Run(llb.Shlex("chown -R envd:envd /opt/conda"),
+			llb.WithCustomName("[internal] configure user permissions"))
+	}
 	return llb.User("envd")(res.Root())
 }
 


### PR DESCRIPTION
When building R environment, we'll see the following error:

```
 => docker-image://docker.io/library/r-base:4.2.0                                                                                                                                0.6s
 => => resolve docker.io/library/r-base:4.2.0                                                                                                                                    0.6ss
 => 💽 (cached) [internal] create user group envd                                                                                                                                 0.0s
 => 💽 (cached) [internal] create user envd                                                                                                                                       0.0s
 => 💽 (cached) [internal] add user envd to sudoers                                                                                                                               0.0s
 => 💽 (cached) [internal] configure user permissions                                                                                                                             0.0s
 => 🔥 (error) [internal] configure user permissions                                                                                                                              0.1s
------                                                                                                                                                                                
 > [internal] configure user permissions:
#0 0.112 chown: cannot access '/opt/conda': No such file or directory
------
ERRO[2022-06-16T19:40:58-04:00] failed to solve LLB: failed to solve: process "chown -R envd:envd /opt/conda" did not complete successfully: exit code: 1  tag="r-basic:dev"
ERRO[2022-06-16T19:40:58-04:00] failed to load docker image: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.41/images/load?quiet=1": context canceled  tag="r-basic:dev"
error: failed to build the image: failed to build: failed to wait error group: failed to solve LLB: failed to solve: process "chown -R envd:envd /opt/conda" did not complete successfully: exit code: 1
error: process "chown -R envd:envd /opt/conda" did not complete successfully: exit code: 1
```
This step should only be needed for Python environment.

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>