### PR TITLE
build: Plain make command only prints out help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,10 +97,10 @@ export GOFLAGS ?= -count=1
 # All targets.
 .PHONY: help lint test build container push addlicense debug debug-local build-local generate clean test-local addlicense-install mockgen-install pypi-build
 
+build: build-local  ## Build the release version of envd
+
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
-
-build: build-local  ## Build the release version of envd
 
 debug: debug-local  ## Build the debug version of envd
 


### PR DESCRIPTION
After https://github.com/tensorchord/envd/pull/421, running `make` only triggers `make help` but it should trigger `make build`. This PR fixes that.

```
➜  envd git:(main) make

Usage:
  make <target>
  help             Display this help
  build            Build the release version of envd
  debug            Build the debug version of envd
  lint             Lint GO code
  generate         Generate mocks
  addlicense       Add license to GO code files
  test             Run the tests
  clean            Clean the outputs and artifacts
  fmt              Run go fmt against code.
  vet              Run go vet against code.
```

Signed-off-by: terrytangyuan <terrytangyuan@gmail.com>