### PR TITLE
Update build.go

### DIFF
--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -36,8 +36,9 @@ var CommandBuild = &cli.Command{
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "tag",
-			Usage:   "Name and optionally a tag in the 'name:tag' format (default: PROJECT:dev)",
+			Usage:   "Name and optionally a tag in the 'name:tag' format",
 			Aliases: []string{"t"},
+			DefaultText: "PROJECT:dev",
 		},
 		&cli.PathFlag{
 			Name:    "file",


### PR DESCRIPTION
(default:PROJECT:dev) can be removed if we use DafaultText.

Signed-off-by: Gui-Yue <78520005+Gui-Yue@users.noreply.github.com>