### PR TITLE
Fix Julia multiple pkg installation bug

### DIFF
--- a/pkg/lang/ir/julia.go
+++ b/pkg/lang/ir/julia.go
@@ -29,7 +29,7 @@ func (g Graph) installJuliaPackages(root llb.State) llb.State {
 
 	var sb strings.Builder
 
-	sb.WriteString(`/usr/local/julia/bin/julia -e 'using Pkg; Pkg.add(`)
+	sb.WriteString(`/usr/local/julia/bin/julia -e 'using Pkg; Pkg.add([`)
 	for i, pkg := range g.JuliaPackages {
 		sb.WriteString(fmt.Sprintf(`"%s"`, pkg))
 		if i != len(g.JuliaPackages)-1 {
@@ -37,7 +37,7 @@ func (g Graph) installJuliaPackages(root llb.State) llb.State {
 		}
 	}
 
-	sb.WriteString(`)'`)
+	sb.WriteString(`])'`)
 
 	// TODO(gaocegege): Support cache.
 	cmd := sb.String()


### PR DESCRIPTION
Fix the following bug when install multiple Julia pkgs

```julia
Pkg.add("IJulia", "Example")
```
```
 => ERROR install julia packages                                                                                                                                                                            6.0s
------
 > install julia packages:
#0 0.737 ERROR: MethodError: no method matching add(::String, ::String)
#0 5.958 Closest candidates are:
#0 5.958   add(::Union{AbstractString, Pkg.Types.PackageSpec}; kwargs...) at /usr/local/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:143
#0 5.958 Stacktrace:
#0 5.958  [1] top-level scope
#0 5.958    @ none:1
------
ERRO[2022-06-28T13:50:32+08:00] failed to load docker image: Post "http://%2Fvar%2Frun%2Fdocker.sock/v1.41/images/load?quiet=1": context canceled  tag="envd-julia:dev"
error: process "/usr/local/julia/bin/julia -e using Pkg; Pkg.add(\"IJulia\", \"Example\")" did not complete successfully: exit code: 1
```