### PR TITLE
Fix: image tag normalized to docker spec

### DIFF
--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -24,6 +24,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/tensorchord/envd/pkg/builder"
+	"github.com/tensorchord/envd/pkg/docker"
 	"github.com/tensorchord/envd/pkg/flag"
 	"github.com/tensorchord/envd/pkg/home"
 	sshconfig "github.com/tensorchord/envd/pkg/ssh/config"
@@ -100,6 +101,10 @@ func build(clicontext *cli.Context) error {
 	if tag == "" {
 		logrus.Debug("tag not specified, using default")
 		tag = fmt.Sprintf("%s:%s", fileutil.Base(buildContext), "dev")
+	}
+	tag, err = docker.NormalizeNamed(tag)
+	if err != nil {
+		return err
 	}
 
 	logger := logrus.WithFields(logrus.Fields{

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -125,6 +125,11 @@ func up(clicontext *cli.Context) error {
 		logrus.Debug("tag not specified, using default")
 		tag = fmt.Sprintf("%s:%s", fileutil.Base(buildContext), "dev")
 	}
+	// The current container engine is only Docker. It should be expaned to support other container engines.
+	tag, err = docker.NormalizeNamed(tag)
+	if err != nil {
+		return err
+	}
 	ctr := fileutil.Base(buildContext)
 
 	detach := clicontext.Bool("detach")

--- a/pkg/docker/docker_suite_test.go
+++ b/pkg/docker/docker_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Docker Suite")
+}

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("docker", func() {
+	When("given the a lowcase tag", func() {
+		It("should return the tag identically", func() {
+			tag := "test:test"
+			newTag, err := NormalizeNamed(tag)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newTag).To(Equal(tag))
+		})
+	})
+	When("given the a uppercase tag", func() {
+		It("should return the tag lowcased", func() {
+			tag := "Test:test"
+			newTag, err := NormalizeNamed(tag)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newTag).NotTo(Equal(tag))
+			Expect(newTag).To(Equal(strings.ToLower(tag)))
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: Qi Chen <aseaday@hotmail.com>
- rename the image tag do lowcased if reference has some uppers
- throw error if the directory  just a digest [a-z0-9]{64}