### PR TITLE
chore: Improve error wrapping and checking

### DIFF
--- a/cmd/envd/main.go
+++ b/cmd/envd/main.go
@@ -48,14 +48,15 @@ func handleErr(err error) {
 	}
 
 	rootCause := errors.Cause(err)
-	if evalErr, ok := rootCause.(*starlark.EvalError); ok {
+	var evalErr starlark.EvalError
+	var syntaxErr syntax.Error
+	if ok := errors.As(err, &evalErr); ok {
 		fmt.Fprintln(os.Stderr, evalErr.Backtrace())
-	} else if syntaxErr, ok := rootCause.(*syntax.Error); ok {
+	} else if ok := errors.As(err, &syntaxErr); ok {
 		fmt.Fprintln(os.Stderr, syntaxErr)
 	} else {
 		fmt.Fprintf(os.Stderr, "error: %v\n", rootCause)
 	}
-
 	os.Exit(1)
 }
 

--- a/pkg/remote/sshd/sshd.go
+++ b/pkg/remote/sshd/sshd.go
@@ -266,8 +266,8 @@ func getExitStatusFromError(err error) int {
 		return 0
 	}
 
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
+	var exitErr exec.ExitError
+	if ok := errors.As(err, &exitErr); !ok {
 		return 1
 	}
 
@@ -366,7 +366,7 @@ func sftpHandler(sess ssh.Session) {
 		logrus.Infof("sftp server init error: %s\n", err)
 		return
 	}
-	if err := server.Serve(); err == io.EOF {
+	if err := server.Serve(); errors.Is(err, io.EOF) {
 		server.Close()
 		logrus.Infoln("sftp client exited session.")
 	} else if err != nil {


### PR DESCRIPTION
This fixes the following error lint checks:

```
comparing with == will fail on wrapped errors. Use errors.Is to check for a specific error
type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors
```


Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>