### PR TITLE
feature:  add label ai.tensorchord.envd.build.manifestBytecodeHash to image for cache robust

### DIFF
--- a/e2e/bytecode_hash_test.go
+++ b/e2e/bytecode_hash_test.go
@@ -40,19 +40,20 @@ func appendSomeToFile(path string) {
 var _ = Describe("bytecode hash cache target", func() {
 	exampleName := "quick-start"
 	It("add some blank to build.envd", func() {
+		testcase := "add-blank"
+		e := NewExample(exampleName, testcase)
 		ctx := context.TODO()
-		BuildImage(exampleName, false)()
+		e.BuildImage(false)()
 		dockerClient := GetDockerClient(ctx)
-		imageSum, err := dockerClient.GetImage(ctx, exampleName+":e2etest")
+		imageSum, err := dockerClient.GetImage(ctx, e.Tag)
 		Expect(err).NotTo(HaveOccurred())
 		oldCreated := imageSum.Created
 		appendSomeToFile("testdata/" + exampleName + "/build.envd")
-		BuildImage(exampleName, false)()
-		imageSum, err = dockerClient.GetImage(ctx, exampleName+":e2etest")
+		e.BuildImage(false)()
+		imageSum, err = dockerClient.GetImage(ctx, e.Tag)
 		Expect(err).NotTo(HaveOccurred())
 		newCreated := imageSum.Created
 		Expect(oldCreated).To(Equal(newCreated))
-		err = RemoveExampleImage(exampleName)
-		Expect(err).NotTo(HaveOccurred())
+		e.RemoveImage()()
 	})
 })

--- a/e2e/bytecode_hash_test.go
+++ b/e2e/bytecode_hash_test.go
@@ -28,7 +28,10 @@ func appendSomeToFile(path string) {
 		panic(err)
 	}
 	blank := "\n\n"
-	f.Write([]byte(blank))
+	_, err = f.Write([]byte(blank))
+	if err != nil {
+		panic(err)
+	}
 	if err := f.Close(); err != nil {
 		panic(err)
 	}
@@ -49,6 +52,7 @@ var _ = Describe("bytecode hash cache target", func() {
 		Expect(err).NotTo(HaveOccurred())
 		newCreated := imageSum.Created
 		Expect(oldCreated).To(Equal(newCreated))
-		RemoveExampleImage(exampleName)
+		err = RemoveExampleImage(exampleName)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/e2e/bytecode_hash_test.go
+++ b/e2e/bytecode_hash_test.go
@@ -49,5 +49,6 @@ var _ = Describe("bytecode hash cache target", func() {
 		Expect(err).NotTo(HaveOccurred())
 		newCreated := imageSum.Created
 		Expect(oldCreated).To(Equal(newCreated))
+		RemoveExampleImage(exampleName)
 	})
 })

--- a/e2e/bytecode_hash_test.go
+++ b/e2e/bytecode_hash_test.go
@@ -1,0 +1,53 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func appendSomeToFile(path string) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		panic(err)
+	}
+	blank := "\n\n"
+	f.Write([]byte(blank))
+	if err := f.Close(); err != nil {
+		panic(err)
+	}
+}
+
+var _ = Describe("bytecode hash cache target", func() {
+	exampleName := "quick-start"
+	It("add some blank to build.envd", func() {
+		ctx := context.TODO()
+		BuildImage(exampleName, false)()
+		dockerClient := GetDockerClient(ctx)
+		imageSum, err := dockerClient.GetImage(ctx, exampleName+":e2etest")
+		Expect(err).NotTo(HaveOccurred())
+		oldCreated := imageSum.Created
+		appendSomeToFile("testdata/" + exampleName + "/build.envd")
+		BuildImage(exampleName, false)()
+		imageSum, err = dockerClient.GetImage(ctx, exampleName+":e2etest")
+		Expect(err).NotTo(HaveOccurred())
+		newCreated := imageSum.Created
+		Expect(oldCreated).To(Equal(newCreated))
+	})
+})

--- a/e2e/e2e_helper.go
+++ b/e2e/e2e_helper.go
@@ -26,15 +26,31 @@ import (
 	sshconfig "github.com/tensorchord/envd/pkg/ssh/config"
 )
 
-func BuildImage(exampleName string, force bool) func() {
+func (e *Example) BuildImage(force bool) func() {
 	return func() {
 		logrus.Info("building quick-start image")
-		var err error
-		if force {
-			err = BuildExampleImage(exampleName, app.New())
-		} else {
-			err = BuildExampleImageWithoutForce(exampleName, app.New())
+		buildContext := "testdata/" + e.Name
+		args := []string{
+			"envd.test", "--debug", "build", "--path", buildContext, "--tag", e.Tag,
 		}
+		if force {
+			args = append(args, "--force")
+		}
+		err := e.app.Run(args)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func (e *Example) RemoveImage() func() {
+	return func() {
+		ctx := context.TODO()
+		dockerClient, err := docker.NewClient(ctx)
+		if err != nil {
+			panic(err)
+		}
+		err = dockerClient.RemoveImage(ctx, e.Tag)
 		if err != nil {
 			panic(err)
 		}
@@ -49,45 +65,23 @@ func GetDockerClient(ctx context.Context) docker.Client {
 	return dockerClient
 }
 
-func RemoveImage(exampleName string) func() {
-	return func() {
-		err := RemoveExampleImage(exampleName)
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
-func RunContainer(exampleName string) func() {
-	return func() {
-		err := RunExampleContainer(exampleName, app.New())
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
-func DestoryContainer(exampleName string) func() {
-	return func() {
-		err := DestroyExampleContainer(exampleName, app.New())
-		if err != nil {
-			panic(err)
-		}
-	}
-}
-
 type Example struct {
 	Name string
+	Tag  string
+	app  app.EnvdApp
 }
 
-func example(name string) *Example {
+func NewExample(name string, testcaseAbbr string) *Example {
+	tag := name + ":" + testcaseAbbr
 	return &Example{
 		Name: name,
+		Tag:  tag,
+		app:  app.New(),
 	}
 }
 
 func (e *Example) Exec(cmd string) string {
-	sshClient := getSSHClient(e.Name)
+	sshClient := e.getSSHClient()
 	ret, err := sshClient.ExecWithOutput(cmd)
 	if err != nil {
 		panic(err)
@@ -95,61 +89,35 @@ func (e *Example) Exec(cmd string) string {
 	return strings.Trim(string(ret), "\n")
 }
 
-func BuildExampleImage(exampleName string, app app.EnvdApp) error {
-	buildContext := "testdata/" + exampleName
-	tag := exampleName + ":e2etest"
-	args := []string{
-		"envd.test", "--debug", "build", "--path", buildContext, "--tag", tag, "--force",
+func (e *Example) RunContainer() func() {
+	return func() {
+		buildContext := "testdata/" + e.Name
+		args := []string{
+			"envd.test", "--debug", "up", "--path", buildContext, "--tag", e.Tag, "--detach", "--force",
+		}
+		err := e.app.Run(args)
+		if err != nil {
+			panic(err)
+		}
 	}
-	err := app.Run(args)
-	return err
 }
 
-func BuildExampleImageWithoutForce(exampleName string, app app.EnvdApp) error {
-	buildContext := "testdata/" + exampleName
-	tag := exampleName + ":e2etest"
-	args := []string{
-		"envd.test", "--debug", "build", "--path", buildContext, "--tag", tag,
+func (e *Example) DestroyContainer() func() {
+	return func() {
+		buildContext := "testdata/" + e.Name
+		args := []string{
+			"envd.test", "--debug", "destroy", "--path", buildContext,
+		}
+		err := e.app.Run(args)
+		if err != nil {
+			panic(err)
+		}
 	}
-	err := app.Run(args)
-	return err
 }
 
-func RemoveExampleImage(exampleName string) error {
-	ctx := context.TODO()
-	dockerClient, err := docker.NewClient(ctx)
-	if err != nil {
-		return err
-	}
-	err = dockerClient.RemoveImage(ctx, exampleName+":e2etest")
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func RunExampleContainer(exampleName string, app app.EnvdApp) error {
-	buildContext := "testdata/" + exampleName
-	tag := exampleName + ":e2etest"
-	args := []string{
-		"envd.test", "--debug", "up", "--path", buildContext, "--tag", tag, "--detach", "--force",
-	}
-	err := app.Run(args)
-	return err
-}
-
-func DestroyExampleContainer(exampleName string, app app.EnvdApp) error {
-	buildContext := "testdata/" + exampleName
-	args := []string{
-		"envd.test", "--debug", "destroy", "--path", buildContext,
-	}
-	err := app.Run(args)
-	return err
-}
-
-func getSSHClient(exampleName string) ssh.Client {
+func (e *Example) getSSHClient() ssh.Client {
 	localhost := "127.0.0.1"
-	port, err := sshconfig.GetPort(exampleName)
+	port, err := sshconfig.GetPort(e.Name)
 	if err != nil {
 		panic(err)
 	}

--- a/e2e/quick_start_test.go
+++ b/e2e/quick_start_test.go
@@ -21,11 +21,13 @@ import (
 
 var _ = Describe("e2e quickstart", Ordered, func() {
 	exampleName := "quick-start"
-	BeforeAll(BuildImage(exampleName, true))
-	BeforeEach(RunContainer(exampleName))
+	testcase := "e2e"
+	e := NewExample(exampleName, testcase)
+	BeforeAll(e.BuildImage(true))
+	BeforeEach(e.RunContainer())
 	It("execute python demo.py", func() {
-		Expect(example(exampleName).Exec("python demo.py")).To(Equal("[2 3 4]"))
+		Expect(e.Exec("python demo.py")).To(Equal("[2 3 4]"))
 	})
-	AfterEach(DestoryContainer(exampleName))
-	AfterAll(RemoveImage(exampleName))
+	AfterEach(e.DestroyContainer())
+	AfterAll(e.RemoveImage())
 })

--- a/e2e/quick_start_test.go
+++ b/e2e/quick_start_test.go
@@ -21,7 +21,7 @@ import (
 
 var _ = Describe("e2e quickstart", Ordered, func() {
 	exampleName := "quick-start"
-	BeforeAll(BuildImage(exampleName))
+	BeforeAll(BuildImage(exampleName, true))
 	BeforeEach(RunContainer(exampleName))
 	It("execute python demo.py", func() {
 		Expect(example(exampleName).Exec("python demo.py")).To(Equal("[2 3 4]"))

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -335,7 +335,7 @@ func (b generalBuilder) checkDepsFileUpdate(ctx context.Context, tag string, man
 		return true, err
 	}
 
-	image, err := dockerClient.GetImageWithCacheHashLabel(ctx, b.manifestCodeHash)
+	image, err := dockerClient.GetImageWithCacheHashLabel(ctx, tag, b.manifestCodeHash)
 	if err != nil {
 		return true, err
 	}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"strconv"
 
 	"github.com/cockroachdb/errors"
 	"github.com/moby/buildkit/client"
@@ -72,7 +71,7 @@ type Options struct {
 
 type generalBuilder struct {
 	Options
-	manifestCodeHash uint64
+	manifestCodeHash string
 	entries          []client.ExportEntry
 
 	logger *logrus.Entry
@@ -176,7 +175,7 @@ func (b generalBuilder) compile(ctx context.Context) (*llb.Definition, error) {
 }
 
 func (b generalBuilder) addBuilderTag(labels *map[string]string) {
-	(*labels)[types.ImageLabelCacheHash] = strconv.FormatUint(b.manifestCodeHash, 16)
+	(*labels)[types.ImageLabelCacheHash] = b.manifestCodeHash
 }
 
 func (b generalBuilder) imageConfig(ctx context.Context) (string, error) {
@@ -336,7 +335,7 @@ func (b generalBuilder) checkDepsFileUpdate(ctx context.Context, tag string, man
 		return true, err
 	}
 
-	image, err := dockerClient.GetImageWithCacheHashLabel(ctx, strconv.FormatUint(b.manifestCodeHash, 16))
+	image, err := dockerClient.GetImageWithCacheHashLabel(ctx, b.manifestCodeHash)
 	if err != nil {
 		return true, err
 	}

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -75,6 +75,7 @@ type Client interface {
 
 	ListImage(ctx context.Context) ([]types.ImageSummary, error)
 	GetImage(ctx context.Context, image string) (types.ImageSummary, error)
+	GetImageWithCacheHashLabel(ctx context.Context, image string) (types.ImageSummary, error)
 	RemoveImage(ctx context.Context, image string) error
 
 	GetInfo(ctx context.Context) (types.Info, error)
@@ -200,6 +201,19 @@ func (c generalClient) GetImage(ctx context.Context, image string) (types.ImageS
 	}
 	if len(images) == 0 {
 		return types.ImageSummary{}, errors.Errorf("image %s not found", image)
+	}
+	return images[0], nil
+}
+
+func (c generalClient) GetImageWithCacheHashLabel(ctx context.Context, hash string) (types.ImageSummary, error) {
+	images, err := c.ImageList(ctx, types.ImageListOptions{
+		Filters: dockerFiltersWithCacheLabel(hash),
+	})
+	if err != nil {
+		return types.ImageSummary{}, err
+	}
+	if len(images) == 0 {
+		return types.ImageSummary{}, errors.Errorf("image with hash %s not found", hash)
 	}
 	return images[0], nil
 }

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -75,7 +75,7 @@ type Client interface {
 
 	ListImage(ctx context.Context) ([]types.ImageSummary, error)
 	GetImage(ctx context.Context, image string) (types.ImageSummary, error)
-	GetImageWithCacheHashLabel(ctx context.Context, image string) (types.ImageSummary, error)
+	GetImageWithCacheHashLabel(ctx context.Context, image string, hash string) (types.ImageSummary, error)
 	RemoveImage(ctx context.Context, image string) error
 
 	GetInfo(ctx context.Context) (types.Info, error)
@@ -205,9 +205,9 @@ func (c generalClient) GetImage(ctx context.Context, image string) (types.ImageS
 	return images[0], nil
 }
 
-func (c generalClient) GetImageWithCacheHashLabel(ctx context.Context, hash string) (types.ImageSummary, error) {
+func (c generalClient) GetImageWithCacheHashLabel(ctx context.Context, image string, hash string) (types.ImageSummary, error) {
 	images, err := c.ImageList(ctx, types.ImageListOptions{
-		Filters: dockerFiltersWithCacheLabel(hash),
+		Filters: dockerFiltersWithCacheLabel(image, hash),
 	})
 	if err != nil {
 		return types.ImageSummary{}, err

--- a/pkg/docker/label.go
+++ b/pkg/docker/label.go
@@ -55,3 +55,9 @@ func dockerFiltersWithName(name string) filters.Args {
 	f.Add("reference", name)
 	return f
 }
+
+func dockerFiltersWithCacheLabel(hash string) filters.Args {
+	f := filters.NewArgs()
+	f.Add("label", fmt.Sprintf("%s=%s", types.ImageLabelCacheHash, hash))
+	return f
+}

--- a/pkg/docker/label.go
+++ b/pkg/docker/label.go
@@ -56,8 +56,9 @@ func dockerFiltersWithName(name string) filters.Args {
 	return f
 }
 
-func dockerFiltersWithCacheLabel(hash string) filters.Args {
+func dockerFiltersWithCacheLabel(name string, hash string) filters.Args {
 	f := filters.NewArgs()
+	f.Add("reference", name)
 	f.Add("label", fmt.Sprintf("%s=%s", types.ImageLabelCacheHash, hash))
 	return f
 }

--- a/pkg/lang/frontend/starlark/interpreter.go
+++ b/pkg/lang/frontend/starlark/interpreter.go
@@ -15,6 +15,10 @@
 package starlark
 
 import (
+	"bytes"
+	"hash/fnv"
+	"io/ioutil"
+
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	"go.starlark.net/repl"
@@ -51,6 +55,30 @@ func NewInterpreter(buildContextDir string) Interpreter {
 		},
 		buildContextDir: buildContextDir,
 	}
+}
+
+func GetEnvdProgramHash(filename string) (uint64, error) {
+	envdSrc, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return 0, err
+	}
+	// No Check builtin or predeclared for now
+	funcAlwaysHas := func(x string) bool {
+		return true
+	}
+	_, prog, err := starlark.SourceProgram(filename, envdSrc, funcAlwaysHas)
+	if err != nil {
+		return 0, err
+	}
+	buf := new(bytes.Buffer)
+	err = prog.Write(buf)
+	if err != nil {
+		return 0, err
+	}
+	h := fnv.New64a()
+	h.Write(buf.Bytes())
+	hashsum := h.Sum64()
+	return hashsum, nil
 }
 
 func (s generalInterpreter) ExecFile(filename string, funcname string) (interface{}, error) {

--- a/pkg/lang/frontend/starlark/interpreter_test.go
+++ b/pkg/lang/frontend/starlark/interpreter_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package starlark
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Starlark", func() {
+	It("should be able to compile envd", func() {
+		filename := "testdata/test.envd"
+		hash, err := GetEnvdProgramHash(filename)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hash).To(Equal(uint64(0x6beb7c4921722246)))
+	})
+})

--- a/pkg/lang/frontend/starlark/interpreter_test.go
+++ b/pkg/lang/frontend/starlark/interpreter_test.go
@@ -24,6 +24,6 @@ var _ = Describe("Starlark", func() {
 		filename := "testdata/test.envd"
 		hash, err := GetEnvdProgramHash(filename)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(hash).To(Equal(uint64(0x6beb7c4921722246)))
+		Expect(hash).To(Equal("6beb7c4921722246"))
 	})
 })

--- a/pkg/lang/frontend/starlark/starlark_suite_test.go
+++ b/pkg/lang/frontend/starlark/starlark_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package starlark
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Starlark Suite")
+}

--- a/pkg/lang/frontend/starlark/testdata/test.envd
+++ b/pkg/lang/frontend/starlark/testdata/test.envd
@@ -1,0 +1,6 @@
+def build():
+    base(os="ubuntu20.04", language="python3")
+    install.python_packages(name = [
+        "numpy",
+    ])
+    shell("zsh")

--- a/pkg/types/label.go
+++ b/pkg/types/label.go
@@ -28,7 +28,7 @@ const (
 	ImageLabelCUDA      = "ai.tensorchord.envd.gpu.cuda"
 	ImageLabelCUDNN     = "ai.tensorchord.envd.gpu.cudnn"
 	ImageLabelContext   = "ai.tensorchord.envd.build.context"
-	ImageLabelCacheHash = "ai.tensorchord.envd.cache.hash"
+	ImageLabelCacheHash = "ai.tensorchord.envd.build.manifestBytecodeHash"
 
 	ImageVendorEnvd = "envd"
 )

--- a/pkg/types/label.go
+++ b/pkg/types/label.go
@@ -28,7 +28,7 @@ const (
 	ImageLabelCUDA      = "ai.tensorchord.envd.gpu.cuda"
 	ImageLabelCUDNN     = "ai.tensorchord.envd.gpu.cudnn"
 	ImageLabelContext   = "ai.tensorchord.envd.build.context"
-	ImageLabelCacheHash = "ai.tensorchord.envd.build.manifestBytecodeHash"
+	ImageLabelCacheHash = "ai.tensorchord.envd.build.digest"
 
 	ImageVendorEnvd = "envd"
 )

--- a/pkg/types/label.go
+++ b/pkg/types/label.go
@@ -20,14 +20,15 @@ const (
 	ContainerLabelRStudioServerAddr = "ai.tensorchord.envd.rstudio.server.address"
 	ContainerLabelSSHPort           = "ai.tensorchord.envd.ssh.port"
 
-	ImageLabelVendor  = "ai.tensorchord.envd.vendor"
-	ImageLabelGPU     = "ai.tensorchord.envd.gpu"
-	ImageLabelAPT     = "ai.tensorchord.envd.apt.packages"
-	ImageLabelPyPI    = "ai.tensorchord.envd.pypi.packages"
-	ImageLabelR       = "ai.tensorchord.envd.r.packages"
-	ImageLabelCUDA    = "ai.tensorchord.envd.gpu.cuda"
-	ImageLabelCUDNN   = "ai.tensorchord.envd.gpu.cudnn"
-	ImageLabelContext = "ai.tensorchord.envd.build.context"
+	ImageLabelVendor    = "ai.tensorchord.envd.vendor"
+	ImageLabelGPU       = "ai.tensorchord.envd.gpu"
+	ImageLabelAPT       = "ai.tensorchord.envd.apt.packages"
+	ImageLabelPyPI      = "ai.tensorchord.envd.pypi.packages"
+	ImageLabelR         = "ai.tensorchord.envd.r.packages"
+	ImageLabelCUDA      = "ai.tensorchord.envd.gpu.cuda"
+	ImageLabelCUDNN     = "ai.tensorchord.envd.gpu.cudnn"
+	ImageLabelContext   = "ai.tensorchord.envd.build.context"
+	ImageLabelCacheHash = "ai.tensorchord.envd.cache.hash"
 
 	ImageVendorEnvd = "envd"
 )


### PR DESCRIPTION
More accurate image cache based on the compiled bytecode'hash.
See e2e/bytecode_hash_test.go for more details.
https://github.com/tensorchord/envd/issues/631
https://github.com/tensorchord/envd/issues/553
Signed-off-by: Qi Chen <aseaday@hotmail.com>