### PR TITLE
fix: Add environment variable PATH in run

### DIFF
--- a/pkg/lang/frontend/starlark/install/install.go
+++ b/pkg/lang/frontend/starlark/install/install.go
@@ -190,7 +190,7 @@ func ruleFuncConda(thread *starlark.Thread, _ *starlark.Builtin,
 	var envFile starlark.String
 
 	if err := starlark.UnpackArgs(ruleConda,
-		args, kwargs, "name?", &name, "channel?", &channel, "envFile?", &envFile); err != nil {
+		args, kwargs, "name?", &name, "channel?", &channel, "env_file?", &envFile); err != nil {
 		return nil, err
 	}
 
@@ -216,7 +216,7 @@ func ruleFuncConda(thread *starlark.Thread, _ *starlark.Builtin,
 		path = &buf
 	}
 
-	logger.Debugf("rule `%s` is invoked, name=%v, channel=%v,envFile=%s", ruleConda, nameList, channelList, envFileStr)
+	logger.Debugf("rule `%s` is invoked, name=%v, channel=%v, env_file=%s", ruleConda, nameList, channelList, envFileStr)
 	if err := ir.CondaPackage(nameList, channelList, path); err != nil {
 		return starlark.None, err
 	}

--- a/pkg/lang/ir/system.go
+++ b/pkg/lang/ir/system.go
@@ -45,6 +45,7 @@ func (g Graph) compileRun(root llb.State) llb.State {
 	if len(g.Exec) == 0 {
 		return root
 	}
+	root = root.AddEnv("PATH", "$PATH:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/conda/bin:/usr/local/julia/bin:/opt/conda/envs/envd/bin")
 	if len(g.Exec) == 1 {
 		return root.Run(llb.Shlex(g.Exec[0])).Root()
 	}


### PR DESCRIPTION
Add default PATH env var to avoid problems like `starting container process caused: exec: "mim": executable file not found in $PATH`

Signed-off-by: Ce Gao <cegao@tensorchord.ai>