### PR TITLE
feat(CLI): Support run command

### DIFF
--- a/e2e/e2e_helper.go
+++ b/e2e/e2e_helper.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/tensorchord/envd/pkg/app"
 	"github.com/tensorchord/envd/pkg/docker"
-	"github.com/tensorchord/envd/pkg/ssh"
 )
 
 func (e *Example) BuildImage(force bool) func() {
@@ -92,7 +91,7 @@ func (e *Example) Exec(cmd string) (string, error) {
 	buffer := new(bytes.Buffer)
 	e.app.Writer = buffer
 
-	return strings.Trim(string(buffer.Bytes()), "\n"), nil
+	return strings.Trim(buffer.String(), "\n"), nil
 }
 
 func (e *Example) RunContainer() func() {
@@ -119,16 +118,4 @@ func (e *Example) DestroyContainer() func() {
 			panic(err)
 		}
 	}
-}
-
-func (e *Example) getSSHClient() (ssh.Client, error) {
-	opt, err := ssh.GetOptions(e.Name)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get ssh options")
-	}
-	sshClient, err := ssh.NewClient(*opt)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create ssh client")
-	}
-	return sshClient, nil
 }

--- a/e2e/e2e_helper.go
+++ b/e2e/e2e_helper.go
@@ -15,6 +15,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"strings"
 
@@ -81,15 +82,17 @@ func NewExample(name string, testcaseAbbr string) *Example {
 }
 
 func (e *Example) Exec(cmd string) (string, error) {
-	sshClient, err := e.getSSHClient()
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get ssh client")
+	args := []string{
+		"envd.test", "run", "--name", e.Name, "--command", cmd,
 	}
-	ret, err := sshClient.ExecWithOutput(cmd)
+	err := e.app.Run(args)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to exec command")
+		return "", errors.Wrap(err, "failed to start `run` command")
 	}
-	return strings.Trim(string(ret), "\n"), nil
+	buffer := new(bytes.Buffer)
+	e.app.Writer = buffer
+
+	return strings.Trim(string(buffer.Bytes()), "\n"), nil
 }
 
 func (e *Example) RunContainer() func() {

--- a/e2e/e2e_helper.go
+++ b/e2e/e2e_helper.go
@@ -84,13 +84,14 @@ func (e *Example) Exec(cmd string) (string, error) {
 	args := []string{
 		"envd.test", "run", "--name", e.Name, "--command", cmd,
 	}
+
+	buffer := new(bytes.Buffer)
+	e.app.Writer = buffer
+
 	err := e.app.Run(args)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to start `run` command")
 	}
-	buffer := new(bytes.Buffer)
-	e.app.Writer = buffer
-
 	return strings.Trim(buffer.String(), "\n"), nil
 }
 

--- a/e2e/e2e_helper.go
+++ b/e2e/e2e_helper.go
@@ -68,15 +68,16 @@ func GetDockerClient(ctx context.Context) docker.Client {
 type Example struct {
 	Name string
 	Tag  string
-	app  app.EnvdApp
+	app  *app.EnvdApp
 }
 
 func NewExample(name string, testcaseAbbr string) *Example {
 	tag := name + ":" + testcaseAbbr
+	app := app.New()
 	return &Example{
 		Name: name,
 		Tag:  tag,
-		app:  app.New(),
+		app:  &app,
 	}
 }
 

--- a/e2e/quick_start_test.go
+++ b/e2e/quick_start_test.go
@@ -26,7 +26,9 @@ var _ = Describe("e2e quickstart", Ordered, func() {
 	BeforeAll(e.BuildImage(true))
 	BeforeEach(e.RunContainer())
 	It("execute python demo.py", func() {
-		Expect(e.Exec("python demo.py")).To(Equal("[2 3 4]"))
+		res, err := e.Exec("python demo.py")
+		Expect(err).To(BeNil())
+		Expect(res).To(Equal("[2 3 4]"))
 	})
 	AfterEach(e.DestroyContainer())
 	AfterAll(e.RemoveImage())

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -60,6 +60,7 @@ func New() EnvdApp {
 		CommandInit,
 		CommandPause,
 		CommandPrune,
+		CommandRun,
 		CommandResume,
 		CommandUp,
 		CommandVersion,

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -64,7 +64,7 @@ To build and push the image to a registry:
 			Name:    "public-key",
 			Usage:   "Path to the public key",
 			Aliases: []string{"pubk"},
-			Value:   sshconfig.GetPublicKey(),
+			Value:   sshconfig.GetPublicKeyOrPanic(),
 			Hidden:  true,
 		},
 		&cli.StringFlag{

--- a/pkg/app/env_describe.go
+++ b/pkg/app/env_describe.go
@@ -23,7 +23,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/tensorchord/envd/pkg/envd"
-	sshconfig "github.com/tensorchord/envd/pkg/ssh/config"
 	"github.com/tensorchord/envd/pkg/types"
 )
 
@@ -36,12 +35,6 @@ var CommandDescribeEnvironment = &cli.Command{
 			Name:    "env",
 			Usage:   "Specify the envd environment to use",
 			Aliases: []string{"e"},
-		},
-		&cli.PathFlag{
-			Name:    "private-key",
-			Usage:   "Path to the private key",
-			Aliases: []string{"k"},
-			Value:   sshconfig.GetPrivateKey(),
 		},
 	},
 	Action: getEnvironmentDependency,

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -1,10 +1,25 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package app
 
 import (
 	"github.com/cockroachdb/errors"
+	"github.com/urfave/cli/v2"
+
 	"github.com/tensorchord/envd/pkg/docker"
 	"github.com/tensorchord/envd/pkg/ssh"
-	"github.com/urfave/cli/v2"
 )
 
 var CommandRun = &cli.Command{

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/tensorchord/envd/pkg/docker"
+	"github.com/tensorchord/envd/pkg/ssh"
+	"github.com/urfave/cli/v2"
+)
+
+var CommandRun = &cli.Command{
+	Name:  "run",
+	Usage: "Spawns a command installed into the environment.",
+	Flags: []cli.Flag{
+		&cli.PathFlag{
+			Name:    "name",
+			Usage:   "Name of the environment",
+			Aliases: []string{"n"},
+		},
+		&cli.StringFlag{
+			Name:    "command",
+			Usage:   "Command to execute",
+			Aliases: []string{"c"},
+		},
+	},
+
+	Action: run,
+}
+
+func run(clicontext *cli.Context) error {
+	name := clicontext.String("name")
+
+	// Check if the container is running.
+	dockerClient, err := docker.NewClient(clicontext.Context)
+	if err != nil {
+		return errors.Wrap(err, "failed to create the docker client")
+	}
+	if isRunning, err :=
+		dockerClient.IsRunning(clicontext.Context, name); err != nil {
+		return errors.Wrapf(
+			err, "failed to check if the environment %s is running", name)
+	} else if !isRunning {
+		return errors.Newf("the environment %s is not running", name)
+	}
+
+	opt, err := ssh.GetOptions(name)
+	if err != nil {
+		return errors.Wrap(err, "failed to get the ssh options")
+	}
+	// SSH into the container and execute the command.
+	sshClient, err := ssh.NewClient(*opt)
+	if err != nil {
+		return errors.Wrap(err, "failed to get the ssh client")
+	}
+	if bytes, err := sshClient.ExecWithOutput(clicontext.String("command")); err != nil {
+		return errors.Wrap(err, "failed to execute the command")
+	} else {
+		println(string(bytes))
+	}
+	return nil
+}

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -15,6 +15,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/errors"
 	"github.com/urfave/cli/v2"
 
@@ -69,7 +71,7 @@ func run(clicontext *cli.Context) error {
 	if bytes, err := sshClient.ExecWithOutput(clicontext.String("command")); err != nil {
 		return errors.Wrap(err, "failed to execute the command")
 	} else {
-		println(string(bytes))
+		fmt.Fprint(clicontext.App.Writer, string(bytes))
 	}
 	return nil
 }

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -69,14 +69,14 @@ var CommandUp = &cli.Command{
 			Name:    "private-key",
 			Usage:   "Path to the private key",
 			Aliases: []string{"k"},
-			Value:   sshconfig.GetPrivateKey(),
+			Value:   sshconfig.GetPrivateKeyOrPanic(),
 			Hidden:  true,
 		},
 		&cli.PathFlag{
 			Name:    "public-key",
 			Usage:   "Path to the public key",
 			Aliases: []string{"pubk"},
-			Value:   sshconfig.GetPublicKey(),
+			Value:   sshconfig.GetPublicKeyOrPanic(),
 			Hidden:  true,
 		},
 		&cli.DurationFlag{
@@ -234,8 +234,10 @@ func up(clicontext *cli.Context) error {
 	}
 
 	if !detach {
-		sshClient, err := ssh.NewClient(
-			localhost, "envd", sshPortInHost, true, clicontext.Path("private-key"), "")
+		opt := ssh.DefaultOptions()
+		opt.PrivateKeyPath = clicontext.Path("private-key")
+		opt.Port = sshPortInHost
+		sshClient, err := ssh.NewClient(opt)
 		if err != nil {
 			return errors.Wrap(err, "failed to create the ssh client")
 		}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Builder", func() {
 			BeforeEach(func() {
 				ctrl := gomock.NewController(GinkgoT())
 				ctrlStarlark := gomock.NewController(GinkgoT())
-				pub := sshconfig.GetPublicKey()
+				pub, err := sshconfig.GetPublicKey()
+				Expect(err).NotTo(HaveOccurred())
 				b = &generalBuilder{
 					Options: Options{
 						ManifestFilePath: manifestFilePath,

--- a/pkg/ssh/config/key.go
+++ b/pkg/ssh/config/key.go
@@ -155,7 +155,25 @@ func DefaultKeyExists() (bool, error) {
 }
 
 // GetPublicKey returns the path to the public key
-func GetPublicKey() string {
+func GetPublicKey() (string, error) {
+	pub, _, err := getDefaultKeyPaths()
+	if err != nil {
+		return "", err
+	}
+	return pub, nil
+}
+
+// GetPrivateKey returns the path to the private key
+func GetPrivateKey() (string, error) {
+	_, pri, err := getDefaultKeyPaths()
+	if err != nil {
+		return "", err
+	}
+	return pri, nil
+}
+
+// GetPublicKeyOrPanic returns the path to the public key or panic.
+func GetPublicKeyOrPanic() string {
 	pub, _, err := getDefaultKeyPaths()
 	if err != nil {
 		logrus.Fatal("Cannot get public key path")
@@ -163,8 +181,8 @@ func GetPublicKey() string {
 	return pub
 }
 
-// GetPrivateKey returns the path to the private key
-func GetPrivateKey() string {
+// GetPrivateKeyOrPanic returns the path to the private key or panic.
+func GetPrivateKeyOrPanic() string {
 	_, pri, err := getDefaultKeyPaths()
 	if err != nil {
 		logrus.Fatal("Cannot get private key path")

--- a/pkg/ssh/config/ssh_config.go
+++ b/pkg/ssh/config/ssh_config.go
@@ -348,7 +348,12 @@ func ReplaceKeyManagedByEnvd(oldKey string, newKey string) error {
 		}
 	}
 
-	err = os.Rename(GetPrivateKey(), newKey)
+	path, err := GetPrivateKey()
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(path, newKey)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Ref #11 

```
NAME:
   envd run - Spawns a command installed into the environment.

USAGE:
   envd run [command options] [arguments...]

OPTIONS:
   --command value, -c value  Command to execute
   --name value, -n value     Name of the environment
```

```
$ envd run --name python-basic --command "pip list"
Package            Version
------------------ ---------
certifi            2022.6.15
charset-normalizer 2.1.0
idna               3.3
pip                22.1.2
requests           2.28.1
setuptools         61.2.0
urllib3            1.26.10
via                0.0.2
wheel              0.37.1
```

Signed-off-by: Ce Gao <cegao@tensorchord.ai>