### PR TITLE
feat(CLI): Add category and refine help text

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -37,6 +37,8 @@ func New() EnvdApp {
 	internalApp.EnableBashCompletion = true
 	internalApp.Name = "envd"
 	internalApp.Usage = "Development environment for data science and AI/ML teams"
+	internalApp.HideHelpCommand = true
+	internalApp.HideVersion = true
 	internalApp.Version = version.GetVersion().String()
 	internalApp.Flags = []cli.Flag{
 		&cli.BoolFlag{
@@ -44,16 +46,17 @@ func New() EnvdApp {
 			Usage: "enable debug output in logs",
 		},
 		&cli.StringFlag{
-			Name:  flag.FlagBuildkitdImage,
-			Usage: "docker image to use for buildkitd",
-			Value: "docker.io/moby/buildkit:v0.10.3",
+			Name:   flag.FlagBuildkitdImage,
+			Usage:  "docker image to use for buildkitd",
+			Value:  "docker.io/moby/buildkit:v0.10.3",
+			Hidden: true,
 		},
 	}
 
 	internalApp.Commands = []*cli.Command{
 		CommandBootstrap,
-		CommandBuild,
 		CommandContext,
+		CommandBuild,
 		CommandDestroy,
 		CommandEnvironment,
 		CommandImage,
@@ -65,6 +68,29 @@ func New() EnvdApp {
 		CommandUp,
 		CommandVersion,
 	}
+
+	internalApp.CustomAppHelpTemplate = ` envd - Development environment for data science and AI/ML teams
+
+ Usage:
+    envd up --path <path>
+
+    envd run --name <env-name> --command "pip list"{{if .VisibleCommands}}
+
+ Build and launch envd environments. Get more information at: https://envd.tensorchord.ai/.
+ To get started with using envd, check out the getting started guide: https://envd.tensorchord.ai/guide/getting-started.html.
+ {{range .VisibleCategories}}{{if .Name}}
+ {{.Name}}:{{range .VisibleCommands}}
+	{{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{else}}{{range .VisibleCommands}}
+ {{join .Names ", "}}{{"\t"}}{{.Usage}}{{end}}{{end}}{{end}}{{end}}{{if .VisibleFlagCategories}}
+
+ Global Options:{{range .VisibleFlagCategories}}
+	{{if .Name}}{{.Name}}
+	{{end}}{{range .Flags}}{{.}}
+	{{end}}{{end}}{{else}}{{if .VisibleFlags}}
+
+ Global Options:
+	{{range $index, $option := .VisibleFlags}}{{if $index}}
+	{{end}}{{wrap $option.String 6}}{{end}}{{end}}{{end}}`
 
 	// Deal with debug flag.
 	var debugEnabled bool

--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -32,8 +32,9 @@ import (
 )
 
 var CommandBootstrap = &cli.Command{
-	Name:  "bootstrap",
-	Usage: "Bootstrap the envd installation including shell autocompletion and buildkit image download",
+	Name:     "bootstrap",
+	Category: CategoryManagement,
+	Usage:    "Bootstrap the envd installation",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "buildkit",

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -20,21 +20,20 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/urfave/cli/v2"
 
 	"github.com/tensorchord/envd/pkg/builder"
 	"github.com/tensorchord/envd/pkg/docker"
-	"github.com/tensorchord/envd/pkg/flag"
 	"github.com/tensorchord/envd/pkg/home"
 	sshconfig "github.com/tensorchord/envd/pkg/ssh/config"
 	"github.com/tensorchord/envd/pkg/util/fileutil"
 )
 
 var CommandBuild = &cli.Command{
-	Name:    "build",
-	Aliases: []string{"b"},
-	Usage:   "Build the envd environment",
+	Name:     "build",
+	Category: CategoryBasic,
+	Aliases:  []string{"b"},
+	Usage:    "Build the envd environment",
 	Description: `
 To build an image using build.envd:
 	$ envd build
@@ -123,11 +122,10 @@ func build(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"build-context":         buildContext,
-		"build-file":            manifest,
-		"config":                cfg,
-		"tag":                   tag,
-		flag.FlagBuildkitdImage: viper.GetString(flag.FlagBuildkitdImage),
+		"build-context": buildContext,
+		"build-file":    manifest,
+		"config":        cfg,
+		"tag":           tag,
 	})
 	debug := clicontext.Bool("debug")
 	output := clicontext.String("output")

--- a/pkg/app/const.go
+++ b/pkg/app/const.go
@@ -1,0 +1,8 @@
+package app
+
+const (
+	CategoryBasic      = "Basic Commands"
+	CategoryManagement = "Management Commands"
+	CategoryAdvanced   = "Advanced Commands"
+	CategoryOther      = "Other Commands"
+)

--- a/pkg/app/const.go
+++ b/pkg/app/const.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package app
 
 const (

--- a/pkg/app/context.go
+++ b/pkg/app/context.go
@@ -19,8 +19,9 @@ import (
 )
 
 var CommandContext = &cli.Command{
-	Name:  "context",
-	Usage: "Manage envd contexts",
+	Name:     "context",
+	Category: CategoryManagement,
+	Usage:    "Manage envd contexts",
 	Subcommands: []*cli.Command{
 		CommandContextCreate,
 		CommandContextList,

--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -27,9 +27,10 @@ import (
 )
 
 var CommandDestroy = &cli.Command{
-	Name:    "destroy",
-	Aliases: []string{"d"},
-	Usage:   "Destroy the envd environment",
+	Name:     "destroy",
+	Category: CategoryBasic,
+	Aliases:  []string{"d"},
+	Usage:    "Destroy the envd environment",
 	Flags: []cli.Flag{
 		&cli.PathFlag{
 			Name:        "path",

--- a/pkg/app/env.go
+++ b/pkg/app/env.go
@@ -30,9 +30,10 @@ import (
 )
 
 var CommandEnvironment = &cli.Command{
-	Name:    "envs",
-	Aliases: []string{"env", "e"},
-	Usage:   "Manage envd environments",
+	Name:     "envs",
+	Category: CategoryBasic,
+	Aliases:  []string{"env", "e"},
+	Usage:    "Manage envd environments",
 
 	Subcommands: []*cli.Command{
 		CommandDescribeEnvironment,

--- a/pkg/app/image.go
+++ b/pkg/app/image.go
@@ -30,9 +30,10 @@ import (
 )
 
 var CommandImage = &cli.Command{
-	Name:    "images",
-	Aliases: []string{"image", "i"},
-	Usage:   "Manage envd images",
+	Name:     "images",
+	Category: CategoryBasic,
+	Aliases:  []string{"image", "i"},
+	Usage:    "Manage envd images",
 
 	Subcommands: []*cli.Command{
 		CommandDescribeImage,

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -29,9 +29,10 @@ import (
 var templatef embed.FS
 
 var CommandInit = &cli.Command{
-	Name:    "init",
-	Aliases: []string{"i"},
-	Usage:   "Initializes the current directory with the build.envd file",
+	Name:     "init",
+	Category: CategoryManagement,
+	Aliases:  []string{"i"},
+	Usage:    "Initializes the current directory with the build.envd file",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:     "lang",

--- a/pkg/app/pause.go
+++ b/pkg/app/pause.go
@@ -23,9 +23,10 @@ import (
 )
 
 var CommandPause = &cli.Command{
-	Name:    "pause",
-	Aliases: []string{"p"},
-	Usage:   "Pause the envd environment",
+	Name:     "pause",
+	Category: CategoryAdvanced,
+	Aliases:  []string{"p"},
+	Usage:    "Pause the envd environment",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "env",

--- a/pkg/app/prune.go
+++ b/pkg/app/prune.go
@@ -23,8 +23,9 @@ import (
 )
 
 var CommandPrune = &cli.Command{
-	Name:  "prune",
-	Usage: "Clean up the build cache",
+	Name:     "prune",
+	Category: CategoryManagement,
+	Usage:    "Clean up the build cache",
 	Flags: []cli.Flag{
 		&cli.DurationFlag{
 			Name:  "keep-duration",

--- a/pkg/app/resume.go
+++ b/pkg/app/resume.go
@@ -23,9 +23,10 @@ import (
 )
 
 var CommandResume = &cli.Command{
-	Name:    "resume",
-	Aliases: []string{"r"},
-	Usage:   "Resume the envd environment",
+	Name:     "resume",
+	Category: CategoryAdvanced,
+	Aliases:  []string{"r"},
+	Usage:    "Resume the envd environment",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:    "env",

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -25,8 +25,9 @@ import (
 )
 
 var CommandRun = &cli.Command{
-	Name:  "run",
-	Usage: "Spawns a command installed into the environment.",
+	Name:     "run",
+	Category: CategoryBasic,
+	Usage:    "Spawns a command installed into the environment.",
 	Flags: []cli.Flag{
 		&cli.PathFlag{
 			Name:    "name",

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -38,9 +38,10 @@ const (
 )
 
 var CommandUp = &cli.Command{
-	Name:    "up",
-	Aliases: []string{"u"},
-	Usage:   "Build and run the envd environment",
+	Name:     "up",
+	Category: CategoryBasic,
+	Aliases:  []string{"u"},
+	Usage:    "Build and run the envd environment",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "tag",

--- a/pkg/app/version.go
+++ b/pkg/app/version.go
@@ -23,10 +23,11 @@ import (
 )
 
 var CommandVersion = &cli.Command{
-	Name:    "version",
-	Aliases: []string{"v"},
-	Usage:   "Print envd version information",
-	Action:  printVersion,
+	Name:     "version",
+	Category: CategoryOther,
+	Aliases:  []string{"v"},
+	Usage:    "Print envd version information",
+	Action:   printVersion,
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "short",


### PR DESCRIPTION
The new help text looks like:

```
 envd - Development environment for data science and AI/ML teams

 Usage:
    envd up --path <path>

    envd run --name <env-name> --command "pip list"

 Build and launch envd environments. Get more information at: https://envd.tensorchord.ai/.
 To get started with using envd, check out the getting started guide: https://envd.tensorchord.ai/guide/getting-started.html.
 
 Advanced Commands:
  pause, p   Pause the envd environment
  resume, r  Resume the envd environment
 Basic Commands:
  build, b          Build the envd environment
  destroy, d        Destroy the envd environment
  envs, env, e      Manage envd environments
  images, image, i  Manage envd images
  run               Spawns a command installed into the environment.
  up, u             Build and run the envd environment
 Management Commands:
  bootstrap  Bootstrap the envd installation
  context    Manage envd contexts
  init, i    Initializes the current directory with the build.envd file
  prune      Clean up the build cache
 Other Commands:
  version, v  Print envd version information

 Global Options:
  --debug     enable debug output in logs (default: false)
  --help, -h  show help (default: false)

```

Signed-off-by: Ce Gao <cegao@tensorchord.ai>