### PR TITLE
feat: support io.mount

### DIFF
--- a/pkg/lang/frontend/starlark/io/const.go
+++ b/pkg/lang/frontend/starlark/io/const.go
@@ -15,5 +15,6 @@
 package io
 
 const (
-	ruleCopy = "io.copy"
+	ruleCopy  = "io.copy"
+	ruleMount = "io.mount"
 )

--- a/pkg/lang/ir/interface.go
+++ b/pkg/lang/ir/interface.go
@@ -196,3 +196,10 @@ func Copy(src, dest string) {
 		Destination: dest,
 	})
 }
+
+func Mount(src, dest string) {
+	DefaultGraph.Mount = append(DefaultGraph.Mount, MountInfo{
+		Source:      src,
+		Destination: dest,
+	})
+}

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -50,8 +50,9 @@ type Graph struct {
 
 	VSCodePlugins []vscode.Plugin
 
-	Exec []string
-	Copy []CopyInfo
+	Exec  []string
+	Copy  []CopyInfo
+	Mount []MountInfo
 
 	*JupyterConfig
 	*GitConfig
@@ -63,6 +64,11 @@ type Graph struct {
 }
 
 type CopyInfo struct {
+	Source      string
+	Destination string
+}
+
+type MountInfo struct {
 	Source      string
 	Destination string
 }


### PR DESCRIPTION
Signed-off-by: Jinjing.Zhou <allenzhou@tensorchord.ai>

Related: https://github.com/tensorchord/envd/issues/673

Support `io.mount(src=...., dest=...)` to mount host directory into container when `envd up`.

For example using dgl
```
io.mount(src="~/.envd/data/dgl", dest="~/.dgl")
```

In future we can simplify the experience, for example `io.mount(src=Envd("dgl"), dest=io.const.dgl_data_path)`