### PR TITLE
ci: Change dependabot PRs to China workday morning time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "saturday"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Shanghai"
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "saturday"
+      day: "monday"
+      time: "10:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
The default time is quite earlier 3am in China and on Saturdays. This new schedule would make more sense.

Signed-off-by: Yuan Tang <terrytangyuan@gmail.com>