### PR TITLE
feat: Avoid gid in base image cache

### DIFF
--- a/base-images/remote-cache/build-and-push-remote-cache.sh
+++ b/base-images/remote-cache/build-and-push-remote-cache.sh
@@ -6,9 +6,10 @@ ROOT_DIR=`dirname $0`
 
 GIT_TAG_VERSION=$(git describe --tags --abbrev=0 | sed -r 's/[v]+//g') # remove v from version
 ENVD_VERSION="${ENVD_VERSION:-$GIT_TAG_VERSION}"
+DOCKER_HUB_ORG="${DOCKER_HUB_ORG:-tensorchord}"
 
 cd ${ROOT_DIR}
 
-envd build --export-cache type=registry,ref=docker.io/tensorchord/python-cache:envd-v${ENVD_VERSION} --force
+envd build --export-cache type=registry,ref=docker.io/${DOCKER_HUB_ORG}/python-cache:envd-v${ENVD_VERSION} --force
 
 cd - > /dev/null

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -51,6 +51,12 @@ func New() EnvdApp {
 			Value:  "docker.io/moby/buildkit:v0.10.3",
 			Hidden: true,
 		},
+		&cli.StringFlag{
+			Name:   flag.FlagDockerOrganization,
+			Usage:  "docker organization to use",
+			Value:  "tensorchord",
+			Hidden: true,
+		},
 	}
 
 	internalApp.Commands = []*cli.Command{
@@ -111,6 +117,8 @@ func New() EnvdApp {
 		// TODO(gaocegege): Add a config struct to keep them.
 		viper.Set(flag.FlagBuildkitdImage, context.String(flag.FlagBuildkitdImage))
 		viper.Set(flag.FlagDebug, debugEnabled)
+		viper.Set(flag.FlagDockerOrganization,
+			context.String(flag.FlagDockerOrganization))
 		return nil
 	}
 

--- a/pkg/flag/consts.go
+++ b/pkg/flag/consts.go
@@ -15,8 +15,9 @@
 package flag
 
 const (
-	FlagCacheDir       = "cache-dir"
-	FlagBuildkitdImage = "buildkitd-image"
-	FlagDebug          = "debug"
-	FlagBuildContext   = "build-context"
+	FlagCacheDir           = "cache-dir"
+	FlagBuildkitdImage     = "buildkitd-image"
+	FlagDebug              = "debug"
+	FlagBuildContext       = "build-context"
+	FlagDockerOrganization = "docker-organization"
 )

--- a/pkg/lang/ir/compile.go
+++ b/pkg/lang/ir/compile.go
@@ -25,8 +25,10 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 
 	"github.com/tensorchord/envd/pkg/config"
+	"github.com/tensorchord/envd/pkg/flag"
 	"github.com/tensorchord/envd/pkg/progress/compileui"
 	"github.com/tensorchord/envd/pkg/types"
 	"github.com/tensorchord/envd/pkg/version"
@@ -144,7 +146,8 @@ func (g Graph) ExposedPorts() (map[string]struct{}, error) {
 func (g Graph) DefaultCacheImporter() (*string, error) {
 	// The base remote cache should work for all languages.
 	res := fmt.Sprintf(
-		"type=registry,ref=docker.io/tensorchord/python-cache:envd-%s",
+		"type=registry,ref=docker.io/%s/python-cache:envd-%s",
+		viper.GetString(flag.FlagDockerOrganization),
 		version.GetGitTagFromVersion())
 	return &res, nil
 }

--- a/pkg/lang/ir/conda.go
+++ b/pkg/lang/ir/conda.go
@@ -134,8 +134,7 @@ func (g Graph) compileCondaEnvironment(root llb.State) (llb.State, error) {
 
 func (g Graph) installConda(root llb.State) (llb.State, error) {
 	run := root.AddEnv("CONDA_VERSION", condaVersionDefault).
-		File(llb.Mkdir("/opt/conda", 0755, llb.WithParents(true),
-			llb.WithUIDGID(g.uid, g.gid)),
+		File(llb.Mkdir("/opt/conda", 0755, llb.WithParents(true)),
 			llb.WithCustomName("[internal] create conda directory")).
 		Run(llb.Shlex(fmt.Sprintf("bash -c '%s'", installCondaBash)),
 			llb.WithCustomName("[internal] install conda"))

--- a/pkg/lang/ir/system.go
+++ b/pkg/lang/ir/system.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 
 	"github.com/tensorchord/envd/pkg/config"
 	"github.com/tensorchord/envd/pkg/flag"
@@ -78,7 +79,8 @@ func (g Graph) compileCopy(root llb.State) llb.State {
 
 func (g *Graph) compileCUDAPackages() llb.State {
 	root := llb.Image(fmt.Sprintf(
-		"docker.io/tensorchord/python:3.9-%s-cuda%s-cudnn%s-envd-%s",
+		"docker.io/%s/python:3.9-%s-cuda%s-cudnn%s-envd-%s",
+		viper.GetString(flag.FlagDockerOrganization),
 		g.OS, *g.CUDA, *g.CUDNN, version.GetGitTagFromVersion()))
 	return root
 }
@@ -127,7 +129,8 @@ func (g *Graph) compileBase() (llb.State, error) {
 	} else if g.CUDA == nil && g.CUDNN == nil {
 		switch g.Language.Name {
 		case "r":
-			base = llb.Image(fmt.Sprintf("docker.io/tensorchord/r-base:4.2-envd-%s",
+			base = llb.Image(fmt.Sprintf("docker.io/%s/r-base:4.2-envd-%s",
+				viper.GetString(flag.FlagDockerOrganization),
 				version.GetGitTagFromVersion()))
 			// r-base image already has GID 1000.
 			// It is a trick, we actually use GID 1000
@@ -139,11 +142,13 @@ func (g *Graph) compileBase() (llb.State, error) {
 			}
 		case "python":
 			base = llb.Image(fmt.Sprintf(
-				"docker.io/tensorchord/python:3.9-ubuntu20.04-envd-%s",
+				"docker.io/%s/python:3.9-ubuntu20.04-envd-%s",
+				viper.GetString(flag.FlagDockerOrganization),
 				version.GetGitTagFromVersion()))
 		case "julia":
 			base = llb.Image(fmt.Sprintf(
-				"docker.io/tensorchord/julia:1.8rc1-ubuntu20.04-envd-%s",
+				"docker.io/%s/julia:1.8rc1-ubuntu20.04-envd-%s",
+				viper.GetString(flag.FlagDockerOrganization),
 				version.GetGitTagFromVersion()))
 		}
 	} else {


### PR DESCRIPTION
We create the dir /opt/conda with the specified uid and gid, thus the base image cache fails to work if the UID is not `1000`, this PR is to fix it.

Besides this, a new hidden global flag `docker-organization` is introduced for debugging purposes.

Signed-off-by: Ce Gao <cegao@tensorchord.ai>