### PR TITLE
fix(CLI): 🔨  use latest version for local build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,7 @@ jobs:
       run: |
           docker login --username "${DOCKERIO_USERNAME}" --password "${DOCKERIO_PASSWORD}"
           ./base-images/build.sh
+          DOCKER_IMAGE_TAG=latest ./base-images/build.sh
   cache_publish:
     name: Build & Push the remote cache
     # only trigger on main repo when tag starts with v

--- a/base-images/build.sh
+++ b/base-images/build.sh
@@ -13,9 +13,6 @@ ENVD_OS="${ENVD_OS:-ubuntu20.04}"
 JULIA_VERSION="${JULIA_VERSION:-1.8rc1}"
 RLANG_VERSION="${RLANG_VERSION:-4.2}"
 
-echo $ENVD_VERSION
-exit 1
-
 cd ${ROOT_DIR}
 # ubuntu 22.04 build require moby/buildkit version greater than 0.8.1
 if ! docker buildx inspect cuda; then

--- a/base-images/build.sh
+++ b/base-images/build.sh
@@ -6,12 +6,15 @@ ROOT_DIR=`dirname $0`
 
 GIT_TAG_VERSION=$(git describe --tags --abbrev=0 | sed -r 's/[v]+//g') # remove v from version
 ENVD_VERSION="${ENVD_VERSION:-$GIT_TAG_VERSION}"
+DOCKER_IMAGE_TAG="${DOCKER_IMAGE_TAG:-$ENVD_VERSION}"
 DOCKER_HUB_ORG="${DOCKER_HUB_ORG:-tensorchord}"
 PYTHON_VERSION="${PYTHON_VERSION:-3.9}"
 ENVD_OS="${ENVD_OS:-ubuntu20.04}"
 JULIA_VERSION="${JULIA_VERSION:-1.8rc1}"
 RLANG_VERSION="${RLANG_VERSION:-4.2}"
 
+echo $ENVD_VERSION
+exit 1
 
 cd ${ROOT_DIR}
 # ubuntu 22.04 build require moby/buildkit version greater than 0.8.1
@@ -26,26 +29,26 @@ docker buildx build \
     --build-arg ENVD_VERSION=${ENVD_VERSION} \
     --build-arg ENVD_SSH_IMAGE=ghcr.io/tensorchord/envd-ssh-from-scratch \
     --pull --push --platform linux/x86_64,linux/arm64 \
-    -t ${DOCKER_HUB_ORG}/python:${PYTHON_VERSION}-${ENVD_OS}-envd-v${ENVD_VERSION} \
+    -t ${DOCKER_HUB_ORG}/python:${PYTHON_VERSION}-${ENVD_OS}-envd-v${DOCKER_IMAGE_TAG} \
     -f python${PYTHON_VERSION}-${ENVD_OS}.Dockerfile .
 docker buildx build --build-arg IMAGE_NAME=docker.io/nvidia/cuda \
     --build-arg ENVD_VERSION=${ENVD_VERSION} \
     --build-arg ENVD_SSH_IMAGE=ghcr.io/tensorchord/envd-ssh-from-scratch \
     --pull --push --platform linux/x86_64,linux/arm64 \
-    -t ${DOCKER_HUB_ORG}/python:${PYTHON_VERSION}-${ENVD_OS}-cuda11.6-cudnn8-envd-v${ENVD_VERSION} \
+    -t ${DOCKER_HUB_ORG}/python:${PYTHON_VERSION}-${ENVD_OS}-cuda11.6-cudnn8-envd-v${DOCKER_IMAGE_TAG} \
     -f python${PYTHON_VERSION}-${ENVD_OS}-cuda11.6.Dockerfile .
 
 # TODO(gaocegege): Support linux/arm64
 docker buildx build \
     --build-arg ENVD_VERSION=${ENVD_VERSION} \
     --build-arg ENVD_SSH_IMAGE=ghcr.io/tensorchord/envd-ssh-from-scratch \
-    -t ${DOCKER_HUB_ORG}/r-base:${RLANG_VERSION}-envd-v${ENVD_VERSION} \
+    -t ${DOCKER_HUB_ORG}/r-base:${RLANG_VERSION}-envd-v${DOCKER_IMAGE_TAG} \
     --pull --push --platform linux/x86_64 \
     -f r${RLANG_VERSION}.Dockerfile .
 docker buildx build \
     --build-arg ENVD_VERSION=${ENVD_VERSION} \
     --build-arg ENVD_SSH_IMAGE=ghcr.io/tensorchord/envd-ssh-from-scratch \
-    -t ${DOCKER_HUB_ORG}/julia:${JULIA_VERSION}-${ENVD_OS}-envd-v${ENVD_VERSION} \
+    -t ${DOCKER_HUB_ORG}/julia:${JULIA_VERSION}-${ENVD_OS}-envd-v${DOCKER_IMAGE_TAG} \
     --pull --push --platform linux/x86_64,linux/arm64 \
     -f julia${JULIA_VERSION}-${ENVD_OS}.Dockerfile .
 cd - > /dev/null

--- a/pkg/lang/ir/system.go
+++ b/pkg/lang/ir/system.go
@@ -77,12 +77,10 @@ func (g Graph) compileCopy(root llb.State) llb.State {
 	return result
 }
 
-func (g *Graph) compileCUDAPackages() llb.State {
-	root := llb.Image(fmt.Sprintf(
+func (g *Graph) compileCUDAPackages(org, version string) llb.State {
+	return llb.Image(fmt.Sprintf(
 		"docker.io/%s/python:3.9-%s-cuda%s-cudnn%s-envd-%s",
-		viper.GetString(flag.FlagDockerOrganization),
-		g.OS, *g.CUDA, *g.CUDNN, version.GetGitTagFromVersion()))
-	return root
+		org, g.OS, *g.CUDA, *g.CUDNN, version))
 }
 
 func (g Graph) compileSystemPackages(root llb.State) llb.State {
@@ -122,6 +120,12 @@ func (g *Graph) compileBase() (llb.State, error) {
 	logger.Debug("compile base image")
 
 	var base llb.State
+	org := viper.GetString(flag.FlagDockerOrganization)
+	v := version.GetGitTagFromVersion()
+	if v == "" {
+		// empty version tag only appear in dev built, set to `latest` if so.
+		v = "latest"
+	}
 	// Do not update user permission in the base image.
 	if g.Image != nil {
 		logger.WithField("image", *g.Image).Debugf("using custom base image")
@@ -129,9 +133,7 @@ func (g *Graph) compileBase() (llb.State, error) {
 	} else if g.CUDA == nil && g.CUDNN == nil {
 		switch g.Language.Name {
 		case "r":
-			base = llb.Image(fmt.Sprintf("docker.io/%s/r-base:4.2-envd-%s",
-				viper.GetString(flag.FlagDockerOrganization),
-				version.GetGitTagFromVersion()))
+			base = llb.Image(fmt.Sprintf("docker.io/%s/r-base:4.2-envd-%s", org, v))
 			// r-base image already has GID 1000.
 			// It is a trick, we actually use GID 1000
 			if g.gid == 1000 {
@@ -142,17 +144,13 @@ func (g *Graph) compileBase() (llb.State, error) {
 			}
 		case "python":
 			base = llb.Image(fmt.Sprintf(
-				"docker.io/%s/python:3.9-ubuntu20.04-envd-%s",
-				viper.GetString(flag.FlagDockerOrganization),
-				version.GetGitTagFromVersion()))
+				"docker.io/%s/python:3.9-ubuntu20.04-envd-%s", org, v))
 		case "julia":
 			base = llb.Image(fmt.Sprintf(
-				"docker.io/%s/julia:1.8rc1-ubuntu20.04-envd-%s",
-				viper.GetString(flag.FlagDockerOrganization),
-				version.GetGitTagFromVersion()))
+				"docker.io/%s/julia:1.8rc1-ubuntu20.04-envd-%s", org, v))
 		}
 	} else {
-		base = g.compileCUDAPackages()
+		base = g.compileCUDAPackages(org, v)
 	}
 	var res llb.ExecState
 


### PR DESCRIPTION
1. detect version git tag for base image, set to `latest` if empty
2. update built.sh to add a tag env var, so that CI could use to change the tag to latest
3. update CI release to build a latest image when released, rebuilt one directly because there should be docker built cache to be used automatically.

Signed-off-by: Wei Zhang <kweizh@gmail.com>