### PR TITLE
fix(release): :hammer: drop go build dep for homebrew

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -107,8 +107,5 @@ brews:
     skip_upload: auto
     caveats: |
       Please run `envd bootstrap` first to bootstrap
-    dependencies:
-      - name: go
-        type: build
     test: |
       system "#{bin}/envd version"


### PR DESCRIPTION
we don't depend on go as we install by downloading the binary from github

Signed-off-by: WeiZhang <kweizh@gmail.com>