### PR TITLE
fix: Remove empty token arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ def build():
         "numpy",
     ])
     shell("zsh")
-    config.jupyter(token="")
+    config.jupyter()
 ```
 
 You can get the endpoint of the running Jupyter notebook via `envd envs ls`.

--- a/examples/mnist/build.envd
+++ b/examples/mnist/build.envd
@@ -9,7 +9,7 @@ def build():
         "numpy",
     ])
     shell("zsh")
-    config.jupyter(token="", port=8888)
+    config.jupyter()
 
 def build_gpu():
     build()

--- a/pkg/app/template/python.envd
+++ b/pkg/app/template/python.envd
@@ -1,6 +1,6 @@
 def build():
     # Use ubuntu20.04 as base image and install python
-    base(os="ubuntu20.04", language="python3")
+    base(os="ubuntu20.04", language="python")
     # Uncomment line below to enable Pypi mirror
     # config.pip_index(url = "https://pypi.tuna.tsinghua.edu.cn/simple")
 
@@ -11,4 +11,4 @@ def build():
     shell("zsh")
 
     # Setup jupyter notebook
-    config.jupyter(token="", port=8888)
+    config.jupyter()


### PR DESCRIPTION
There is no need to add `token=""` in jupyter func.

Signed-off-by: Ce Gao <cegao@tensorchord.ai>