### PR TITLE
chore: Add code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+*             @kemingy @VoVAllen @gaocegege
+
+*.go          @aseaday @zwpaper
+go.*          @gaocegege
+
+*.py          @VoVAllen @kemingy
+
+base-images/  @gaocegege


### PR DESCRIPTION
Ref https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

CODEOWNERS is used by GitHub to get reviews from specified owners.

/cc @zwpaper @aseaday 

Signed-off-by: Ce Gao <cegao@tensorchord.ai>