### PR TITLE
fix: panic if daemon command is invalid

### DIFF
--- a/pkg/lang/frontend/starlark/runtime/runtime.go
+++ b/pkg/lang/frontend/starlark/runtime/runtime.go
@@ -15,8 +15,6 @@
 package runtime
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"

--- a/pkg/lang/frontend/starlark/runtime/runtime.go
+++ b/pkg/lang/frontend/starlark/runtime/runtime.go
@@ -78,8 +78,7 @@ func ruleFuncDaemon(thread *starlark.Thread, _ *starlark.Builtin,
 		for i := 0; i < commands.Len(); i++ {
 			args, ok := commands.Index(i).(*starlark.List)
 			if !ok {
-				logger.Warnf("cannot parse %s into a list of string", commands.Index(i).String())
-				continue
+				return nil, fmt.Errorf("invalid daemon commands (%s)", commands.Index(i).String())
 			}
 			argList := []string{}
 			for j := 0; j < args.Len(); j++ {

--- a/pkg/lang/frontend/starlark/runtime/runtime.go
+++ b/pkg/lang/frontend/starlark/runtime/runtime.go
@@ -78,7 +78,7 @@ func ruleFuncDaemon(thread *starlark.Thread, _ *starlark.Builtin,
 		for i := 0; i < commands.Len(); i++ {
 			args, ok := commands.Index(i).(*starlark.List)
 			if !ok {
-				return nil, fmt.Errorf("invalid daemon commands (%s)", commands.Index(i).String())
+				return nil, errors.Newf("invalid daemon commands (%s)", commands.Index(i).String())
 			}
 			argList := []string{}
 			for j := 0; j < args.Len(); j++ {

--- a/pkg/lang/frontend/starlark/runtime/runtime.go
+++ b/pkg/lang/frontend/starlark/runtime/runtime.go
@@ -15,9 +15,9 @@
 package runtime
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
@@ -51,7 +51,7 @@ func ruleFuncCommand(thread *starlark.Thread, _ *starlark.Builtin,
 	commandsMap := make(map[string]string)
 	for _, tuple := range commands.Items() {
 		if len(tuple) != 2 {
-			return nil, fmt.Errorf("invalid command in %s", ruleCommand)
+			return nil, errors.Newf("invalid command in %s", ruleCommand)
 		}
 
 		commandsMap[tuple[0].(starlark.String).GoString()] =
@@ -131,7 +131,7 @@ func ruleFuncEnviron(thread *starlark.Thread, _ *starlark.Builtin,
 	envMap := make(map[string]string)
 	for _, tuple := range env.Items() {
 		if len(tuple) != 2 {
-			return nil, fmt.Errorf("invalid env (%s)", tuple.String())
+			return nil, errors.Newf("invalid env (%s)", tuple.String())
 		}
 
 		envMap[tuple[0].(starlark.String).GoString()] = tuple[1].(starlark.String).GoString()


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

The warning may not be noticed by users.

Let it panic so users know something wrong in the `envd` file.