### PR TITLE
bug: Fix detach instruction message

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -249,7 +249,7 @@ func (c generalClient) Attach() error {
 	logrus.Debugf("executing command over ssh: '%s'", cmd)
 	err = session.Run(cmd)
 	if err == nil {
-		logrus.Infof("Detached successfully. You can attach to the container with command `ssh %s`\n",
+		logrus.Infof("Detached successfully. You can attach to the container with command `ssh %s.envd`\n",
 			ir.DefaultGraph.EnvironmentName)
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: VoVAllen <allenzhou@tensorchord.ai>

The right command to attach to container is `ssh mnist.envd`