### PR TITLE
fix: include update repo

### DIFF
--- a/pkg/util/fileutil/file.go
+++ b/pkg/util/fileutil/file.go
@@ -175,7 +175,7 @@ func DownloadOrUpdateGitRepo(url string) (path string, err error) {
 		logger.Debug("try to pull latest")
 		err = wt.Pull(&git.PullOptions{})
 		if err != nil && errors.Is(err, git.NoErrAlreadyUpToDate) {
-			return
+			return path, nil
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

Previously, this will still trigger the `NoErrAlreadyUpToDate` error.