### PR TITLE
feat: support micromamba as an alternative to miniconda

### DIFF
--- a/pkg/lang/frontend/starlark/config/config.go
+++ b/pkg/lang/frontend/starlark/config/config.go
@@ -178,16 +178,16 @@ func ruleFuncRStudioServer(thread *starlark.Thread, _ *starlark.Builtin,
 func ruleFuncCondaChannel(thread *starlark.Thread, _ *starlark.Builtin,
 	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var channel string
-	var useConda bool
+	var useMamba bool
 
 	if err := starlark.UnpackArgs(ruleCondaChannel, args, kwargs,
-		"channel?", &channel, "use_conda?", &useConda); err != nil {
+		"channel?", &channel, "use_conda?", &useMamba); err != nil {
 		return nil, err
 	}
 
-	logger.Debugf("rule `%s` is invoked, channel=%s, use_conda=%t\n",
-		ruleCondaChannel, channel, useConda)
-	if err := ir.CondaChannel(channel, useConda); err != nil {
+	logger.Debugf("rule `%s` is invoked, channel=%s, use_mamba=%t\n",
+		ruleCondaChannel, channel, useMamba)
+	if err := ir.CondaChannel(channel, useMamba); err != nil {
 		return nil, err
 	}
 

--- a/pkg/lang/frontend/starlark/config/config.go
+++ b/pkg/lang/frontend/starlark/config/config.go
@@ -177,18 +177,17 @@ func ruleFuncRStudioServer(thread *starlark.Thread, _ *starlark.Builtin,
 
 func ruleFuncCondaChannel(thread *starlark.Thread, _ *starlark.Builtin,
 	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var channel starlark.String
+	var channel string
+	var useConda bool
 
 	if err := starlark.UnpackArgs(ruleCondaChannel, args, kwargs,
-		"channel?", &channel); err != nil {
+		"channel?", &channel, "use_conda?", &useConda); err != nil {
 		return nil, err
 	}
 
-	channelStr := channel.GoString()
-
-	logger.Debugf("rule `%s` is invoked, channel=%s",
-		ruleCondaChannel, channelStr)
-	if err := ir.CondaChannel(channelStr); err != nil {
+	logger.Debugf("rule `%s` is invoked, channel=%s, use_conda=%t\n",
+		ruleCondaChannel, channel, useConda)
+	if err := ir.CondaChannel(channel, useConda); err != nil {
 		return nil, err
 	}
 

--- a/pkg/lang/frontend/starlark/config/config.go
+++ b/pkg/lang/frontend/starlark/config/config.go
@@ -181,7 +181,7 @@ func ruleFuncCondaChannel(thread *starlark.Thread, _ *starlark.Builtin,
 	var useMamba bool
 
 	if err := starlark.UnpackArgs(ruleCondaChannel, args, kwargs,
-		"channel?", &channel, "use_conda?", &useMamba); err != nil {
+		"channel?", &channel, "use_mamba?", &useMamba); err != nil {
 		return nil, err
 	}
 

--- a/pkg/lang/frontend/starlark/universe/universe.go
+++ b/pkg/lang/frontend/starlark/universe/universe.go
@@ -44,21 +44,18 @@ func RegisterBuildContext(buildContextDir string) {
 
 func ruleFuncBase(thread *starlark.Thread, _ *starlark.Builtin,
 	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var os, language, image starlark.String
+	var os, language, image string
+	var useConda bool
 
 	if err := starlark.UnpackArgs(ruleBase, args, kwargs,
-		"os?", &os, "language?", &language, "image?", &image); err != nil {
+		"os?", &os, "language?", &language, "image?", &image, "use_conda?", &useConda); err != nil {
 		return nil, err
 	}
 
-	osStr := os.GoString()
-	langStr := language.GoString()
-	imageStr := image.GoString()
+	logger.Debugf("rule `%s` is invoked, os=%s, language=%s, image=%s\n",
+		ruleBase, os, language, image)
 
-	logger.Debugf("rule `%s` is invoked, os=%s, language=%s, image=%s",
-		ruleBase, osStr, langStr, imageStr)
-
-	err := ir.Base(osStr, langStr, imageStr)
+	err := ir.Base(os, language, image)
 	return starlark.None, err
 }
 

--- a/pkg/lang/ir/conda.go
+++ b/pkg/lang/ir/conda.go
@@ -29,10 +29,12 @@ import (
 
 const (
 	condaVersionDefault = "py39_4.11.0"
+	installMambaBash    = "curl micro.mamba.pm/install.sh | bash"
 )
 
 var (
 	condarc = fileutil.EnvdHomeDir(".condarc")
+	mambarc = fileutil.EnvdHomeDir(".mambarc")
 	//go:embed install-conda.sh
 	installCondaBash string
 )

--- a/pkg/lang/ir/install-conda.sh
+++ b/pkg/lang/ir/install-conda.sh
@@ -1,4 +1,4 @@
-set -x && \
+set -euo pipefail && \
 UNAME_M="$(uname -m)" && \
 if [ "${UNAME_M}" = "x86_64" ]; then \
 	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \

--- a/pkg/lang/ir/install-mamba.sh
+++ b/pkg/lang/ir/install-mamba.sh
@@ -11,4 +11,4 @@ mkdir -p ${MAMBA_BIN_DIR} && \
 curl -Ls https://micro.mamba.pm/api/micromamba/linux-${ARCH}/latest | tar -xvj -C ${MAMBA_BIN_DIR} --strip-components=1 bin/micromamba && \
 ln -s ${MAMBA_BIN_DIR}/micromamba ${MAMBA_BIN_DIR}/conda && \
 echo -e "channels:\n  - conda-forge" > ${MAMBA_ROOT_PREFIX}/.mambarc
-echo -e "#!/bin/sh\n\. ${MAMBA_ROOT_PREFIX}/etc/profile.d/micromamba.sh || return $?\nmicromamba activate \"$@\"" > ${MAMBA_BIN_DIR}/activate
+echo -e "#!/bin/sh\n\. ${MAMBA_ROOT_PREFIX}/etc/profile.d/micromamba.sh || return \$?\nmicromamba activate \"\$@\"" > ${MAMBA_BIN_DIR}/activate

--- a/pkg/lang/ir/install-mamba.sh
+++ b/pkg/lang/ir/install-mamba.sh
@@ -1,0 +1,13 @@
+set -euo pipefail && \
+ARCH="$(uname -m)" && \
+if [[ "${ARCH}" == "aarch64" ]]; then \
+    ARCH="aarch64"; \
+elif [[ "${ARCH}" == "ppc64le" ]]; then \
+    ARCH="ppc64le"; \
+else \
+    ARCH="64"; \
+fi && \
+mkdir -p ${MAMBA_BIN_DIR} && \
+curl -Ls https://micro.mamba.pm/api/micromamba/linux-${ARCH}/latest | tar -xvj -C ${MAMBA_BIN_DIR} --strip-components=1 bin/micromamba && \
+ln -s ${MAMBA_BIN_DIR}/micromamba ${MAMBA_BIN_DIR}/conda && \
+echo -e "channels:\n  - conda-forge" > ${MAMBA_ROOT_PREFIX}/.condarc

--- a/pkg/lang/ir/install-mamba.sh
+++ b/pkg/lang/ir/install-mamba.sh
@@ -10,4 +10,5 @@ fi && \
 mkdir -p ${MAMBA_BIN_DIR} && \
 curl -Ls https://micro.mamba.pm/api/micromamba/linux-${ARCH}/latest | tar -xvj -C ${MAMBA_BIN_DIR} --strip-components=1 bin/micromamba && \
 ln -s ${MAMBA_BIN_DIR}/micromamba ${MAMBA_BIN_DIR}/conda && \
-echo -e "channels:\n  - conda-forge" > ${MAMBA_ROOT_PREFIX}/.condarc
+echo -e "channels:\n  - conda-forge" > ${MAMBA_ROOT_PREFIX}/.mambarc
+echo -e "#!/bin/sh\n\. ${MAMBA_ROOT_PREFIX}/etc/profile.d/micromamba.sh || return $?\nmicromamba activate \"$@\"" > ${MAMBA_BIN_DIR}/activate

--- a/pkg/lang/ir/interface.go
+++ b/pkg/lang/ir/interface.go
@@ -34,7 +34,6 @@ func Base(os, language, image string) error {
 	if image != "" {
 		DefaultGraph.Image = &image
 	}
-	if useConda
 	return nil
 }
 
@@ -144,16 +143,13 @@ func Git(name, email, editor string) error {
 	return nil
 }
 
-func CondaChannel(channel string) error {
-	if channel == "" {
-		return errors.New("channel is required")
-	}
-
+func CondaChannel(channel string, useConda bool) error {
 	if !DefaultGraph.CondaEnabled() {
 		DefaultGraph.CondaConfig = &CondaConfig{}
 	}
 
 	DefaultGraph.CondaConfig.CondaChannel = &channel
+	DefaultGraph.CondaConfig.UseMiniConda = useConda
 	return nil
 }
 

--- a/pkg/lang/ir/interface.go
+++ b/pkg/lang/ir/interface.go
@@ -143,13 +143,13 @@ func Git(name, email, editor string) error {
 	return nil
 }
 
-func CondaChannel(channel string, useConda bool) error {
+func CondaChannel(channel string, useMamba bool) error {
 	if !DefaultGraph.CondaEnabled() {
 		DefaultGraph.CondaConfig = &CondaConfig{}
 	}
 
 	DefaultGraph.CondaConfig.CondaChannel = &channel
-	DefaultGraph.CondaConfig.UseMiniConda = useConda
+	DefaultGraph.CondaConfig.UseMicroMamba = useMamba
 	return nil
 }
 

--- a/pkg/lang/ir/interface.go
+++ b/pkg/lang/ir/interface.go
@@ -34,6 +34,7 @@ func Base(os, language, image string) error {
 	if image != "" {
 		DefaultGraph.Image = &image
 	}
+	if useConda
 	return nil
 }
 

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -111,6 +111,7 @@ type CondaConfig struct {
 	AdditionalChannels []string
 	CondaChannel       *string
 	CondaEnvFileName   string
+	UseMiniConda       bool
 }
 
 type GitConfig struct {

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -111,7 +111,7 @@ type CondaConfig struct {
 	AdditionalChannels []string
 	CondaChannel       *string
 	CondaEnvFileName   string
-	UseMiniConda       bool
+	UseMicroMamba      bool
 }
 
 type GitConfig struct {


### PR DESCRIPTION
Signed-off-by: Keming kemingyang@tensorchord.ai

Add the following code to your `~/.config/envd/config.envd` to try this new feature:

```py
config.conda_channel(use_mamba=True)
```

