### PR TITLE
chore: use conda-forge as default miniconda channel

### DIFF
--- a/pkg/lang/ir/install-conda.sh
+++ b/pkg/lang/ir/install-conda.sh
@@ -21,6 +21,7 @@ sh /tmp/miniconda.sh -b -u -p /opt/conda && \
 rm /tmp/miniconda.sh /tmp/shasum && \
 echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
 echo "conda activate base" >> ~/.bashrc && \
+echo -e "channels:\n  - conda-forge" > /opt/conda/.condarc && \
 find /opt/conda/ -follow -type f -name '*.a' -delete && \
 find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
 /opt/conda/bin/conda clean -afy


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

According to:
* The founder of Anaconda https://www.reddit.com/r/Python/comments/iqsk3y/comment/gqdqrk9/
* Anaconda FAQ https://www.anaconda.com/blog/anaconda-commercial-edition-faq

I guess we should be able to use `miniconda` with the `conda-forge` channel.

BTW, we already support `micromamba` as an alternative. Although the CLI is not 100% compatible.
