### PR TITLE
chore: add py3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
 ]
 
 


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

Since [cibuildwheel v2.9.0](https://github.com/pypa/cibuildwheel/releases/tag/v2.9.0), CPython 3.11 wheels are built by default.
