### PR TITLE
chore: fix cuda & cudnn version in the examples

### DIFF
--- a/e2e/docs/testdata/complex/build.envd
+++ b/e2e/docs/testdata/complex/build.envd
@@ -18,7 +18,7 @@ deb https://mirror.sjtu.edu.cn/ubuntu focal-security main restricted universe mu
     install.python_packages(name = [
         "numpy",
     ])
-    install.cuda(version="11.2", cudnn="8")
+    install.cuda(version="11.2.0", cudnn="8")
     shell("zsh")
     install.apt_packages(name = [
         "htop"

--- a/examples/conda/build.envd
+++ b/examples/conda/build.envd
@@ -26,4 +26,4 @@ custom_channels:
     install.python_packages(name = [
         "flask"
     ])
-    install.cuda(version="11.2", cudnn="8")
+    install.cuda(version="11.2.0", cudnn="8")

--- a/examples/dgl/build.envd
+++ b/examples/dgl/build.envd
@@ -16,7 +16,7 @@ def build_gpu():
     base(os="ubuntu20.04", language="python3")  
 
     # install cuda
-    install.cuda(version="11.2", cudnn="8")
+    install.cuda(version="11.2.0", cudnn="8")
 
     # Add the packages you are using here
     install.python_packages(["numpy"])

--- a/examples/mnist/build.envd
+++ b/examples/mnist/build.envd
@@ -13,4 +13,4 @@ def build():
 
 def build_gpu():
     build()
-    install.cuda(version="11.2", cudnn="8")
+    install.cuda(version="11.2.0", cudnn="8")


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

Need to add this because [Nvidia CUDA devel tag](https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=devel-ubuntu) requires the patch version.