### PR TITLE
fix(zsh): ignore inserting zsh-completion if system don't have zsh shell

### DIFF
--- a/pkg/autocomplete/zsh.go
+++ b/pkg/autocomplete/zsh.go
@@ -73,7 +73,7 @@ func InsertZSHCompleteEntry() error {
 	dirs := []string{
 		"/usr/share/zsh/site-functions",
 		"/usr/local/share/zsh/site-functions",
-		fmt.Sprintf("%s/.config/envd", homeDir),
+		fileutil.DefaultConfigDir,
 	}
 
 	var f *os.File

--- a/pkg/autocomplete/zsh.go
+++ b/pkg/autocomplete/zsh.go
@@ -71,8 +71,8 @@ func InsertZSHCompleteEntry() error {
 	filename := "envd.zsh"
 	homeDir := os.Getenv("HOME")
 	dirs := []string{
-		//"/usr/share/zsh/site-functions",
-		//"/usr/local/share/zsh/site-functions",
+		"/usr/share/zsh/site-functions",
+		"/usr/local/share/zsh/site-functions",
 		fmt.Sprintf("%s/.config/envd", homeDir),
 	}
 

--- a/pkg/autocomplete/zsh.go
+++ b/pkg/autocomplete/zsh.go
@@ -55,7 +55,7 @@ compdef _cli_zsh_autocomplete envd`
 
 var zshConfig = `
 # envd zsh-completion
-[ -f ~/.envd.zsh ] && source ~/.envd.zsh
+[ -f ~/.config/envd/envd.zsh ] && source ~/.config/envd/envd.zsh
 `
 
 // If debugging this, it might be required to run `rm ~/.zcompdump*` to remove the cache
@@ -68,12 +68,12 @@ func InsertZSHCompleteEntry() error {
 	}
 
 	// should be the same on linux and macOS
-	filename := ".envd.zsh"
+	filename := "envd.zsh"
 	homeDir := os.Getenv("HOME")
 	dirs := []string{
-		"/usr/share/zsh/site-functions",
-		"/usr/local/share/zsh/site-functions",
-		homeDir,
+		//"/usr/share/zsh/site-functions",
+		//"/usr/local/share/zsh/site-functions",
+		fmt.Sprintf("%s/.config/envd", homeDir),
 	}
 
 	var f *os.File


### PR DESCRIPTION
resolves: #552 

- Change envd's zsh-completion script name to `.envd.zsh`
- Try to write the `.envd.zsh` by the following methods:
  1. write `/usr/share/zsh/site-functions/.envd.zsh` directly.
  2. write `/usr/local/share/zsh/site-functions/.envd.zsh` directly.
  3. write `$HOME/.envd.zsh` directly and add loaded script into the `$HOME/.zshrc`

Signed-off-by: Triple-Z <me@triplez.cn>