### PR TITLE
chore: Regroup run command

### DIFF
--- a/pkg/lang/ir/compile.go
+++ b/pkg/lang/ir/compile.go
@@ -56,7 +56,7 @@ func NewGraph() *Graph {
 		RPackages:       []string{},
 		JuliaPackages:   []string{},
 		SystemPackages:  []string{},
-		Exec:            []string{},
+		Exec:            [][]string{},
 		UserDirectories: []string{},
 		Shell:           shellBASH,
 		CondaConfig:     conda,

--- a/pkg/lang/ir/interface.go
+++ b/pkg/lang/ir/interface.go
@@ -135,7 +135,7 @@ func RStudioServer() error {
 
 func Run(commands []string) error {
 	// TODO(gaocegege): Support order-based exec.
-	DefaultGraph.Exec = append(DefaultGraph.Exec, commands...)
+	DefaultGraph.Exec = append(DefaultGraph.Exec, commands)
 	return nil
 }
 

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -55,7 +55,7 @@ type Graph struct {
 	VSCodePlugins   []vscode.Plugin
 	UserDirectories []string
 
-	Exec       []string
+	Exec       [][]string
 	Copy       []CopyInfo
 	Mount      []MountInfo
 	HTTP       []HTTPInfo

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -139,7 +139,7 @@ func NewClient(opt Options) (Client, error) {
 				return nil, errors.Wrap(err, "forwarding agent to client failed")
 			}
 		} else {
-			logrus.Warn("failed to get the environment variable SSH_AUTH_SOCK")
+			logrus.Warn("SSH Agent Forwarding is disabled. This will have no impact on your normal use if you do not use the ssh key on the host.")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Jinjing.Zhou <allenzhou@tensorchord.ai>

Now each `run` command will form a separate `bash -c` script, which makes context clean and is better for cache