### PR TITLE
feat: enable convenient vscode debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ vendor/
 go.work
 
 .vscode/*
+!.vscode/launch.json
 .idea
 
 # Local History for Visual Studio Code

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "envd up",
+      "type": "go",
+      "request": "launch",
+      "mode": "exec",
+      "program": "${workspaceFolder}/debug-bin/envd",
+      "cwd": "directory containing build.envd",
+      "args": [
+        "up"
+      ]
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ generate: mockgen-install  ## Generate mocks
 # It is used by vscode to attach into the process.
 debug-local:
 	@for target in $(TARGETS); do                                                      \
-	  CGO_ENABLED=$(CGO_ENABLED) go build -trimpath                                    \
+	  CGO_ENABLED=$(CGO_ENABLED) go build                                              \
 	  	-v -o $(DEBUG_DIR)/$${target}                                                  \
 	  	-gcflags='all=-N -l'                                                           \
 	    $(CMD_DIR)/$${target};                                                         \


### PR DESCRIPTION
With this PR, we can debug a binary built with `make debug-local` in vscode easily.

<img width="1573" alt="image" src="https://user-images.githubusercontent.com/8433465/197792069-0d83f5f5-6569-4130-93b2-4cb4c923d34d.png">
