### PR TITLE
fix: Fix the order to make conda cache always work

### DIFF
--- a/pkg/lang/ir/conda.go
+++ b/pkg/lang/ir/conda.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/tensorchord/envd/pkg/flag"
-	"github.com/tensorchord/envd/pkg/util/fileutil"
 )
 
 const (
@@ -137,20 +136,6 @@ func (g Graph) compileCondaEnvironment(root llb.State) (llb.State, error) {
 	run = run.Run(llb.Shlex(cmd),
 		llb.WithCustomNamef("[internal] create conda environment: %s", cmd))
 
-	switch g.Shell {
-	case shellBASH:
-		run = run.Run(
-			llb.Shlex(
-				fmt.Sprintf(`bash -c 'echo "source %s/activate envd" >> %s'`,
-					condaBinDir, fileutil.EnvdHomeDir(".bashrc"))),
-			llb.WithCustomName("[internal] add conda environment to bashrc"))
-	case shellZSH:
-		run = run.Run(
-			llb.Shlex(fmt.Sprintf("bash -c \"%s\"", g.condaInitShell(g.Shell))),
-			llb.WithCustomNamef("[internal] initialize conda %s environment", g.Shell)).Run(
-			llb.Shlex(fmt.Sprintf(`bash -c 'echo "source %s/activate envd" >> %s'`, condaBinDir, fileutil.EnvdHomeDir(".zshrc"))),
-			llb.WithCustomName("[internal] add conda environment to zshrc"))
-	}
 	return run.Root(), nil
 }
 

--- a/pkg/lang/ir/interface.go
+++ b/pkg/lang/ir/interface.go
@@ -117,7 +117,6 @@ func JuliaPackageServer(url string) error {
 
 func Shell(shell string) error {
 	DefaultGraph.Shell = shell
-	DefaultGraph.SystemPackages = append(DefaultGraph.SystemPackages, shell)
 	return nil
 }
 

--- a/pkg/lang/ir/julia.go
+++ b/pkg/lang/ir/julia.go
@@ -23,11 +23,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (g Graph) compileJulia(aptStage llb.State) (llb.State, error) {
+func (g Graph) compileJulia(baseStage llb.State) (llb.State, error) {
 	if err := g.compileJupyter(); err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile jupyter")
 	}
 
+	aptStage := g.compileUbuntuAPT(baseStage)
 	builtinSystemStage := aptStage
 
 	sshStage, err := g.copySSHKey(builtinSystemStage)

--- a/pkg/lang/ir/python.go
+++ b/pkg/lang/ir/python.go
@@ -45,41 +45,45 @@ func (g Graph) getAppropriatePythonVersion() (string, error) {
 	return "", errors.Errorf("python version %s is not supported", version)
 }
 
-func (g Graph) compilePython(aptStage llb.State) (llb.State, error) {
-	condaChanelStage := g.compileCondaChannel(aptStage)
-	pypiMirrorStage := g.compilePyPIIndex(condaChanelStage)
-
+func (g Graph) compilePython(baseStage llb.State) (llb.State, error) {
 	if err := g.compileJupyter(); err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile jupyter")
 	}
-	// Conda affects shell and python, thus we cannot do it in parallel.
-	shellStage, err := g.compileShell(pypiMirrorStage)
-	if err != nil {
-		return llb.State{}, errors.Wrap(err, "failed to compile shell")
-	}
+	systemStage := g.compileSystemPackages(baseStage)
 
-	systemStage := g.compileSystemPackages(shellStage)
-
-	condaEnvStage, err := g.compileCondaEnvironment(shellStage)
+	condaChannelStage := g.compileCondaChannel(baseStage)
+	condaEnvStage, err := g.compileCondaEnvironment(condaChannelStage)
 	if err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile conda environment")
 	}
 
-	diffCondaEnvStage := llb.Diff(shellStage, condaEnvStage,
+	// Conda affects shell and python, thus we cannot do it in parallel.
+	shellStage, err := g.compileShell(baseStage)
+	if err != nil {
+		return llb.State{}, errors.Wrap(err, "failed to compile shell")
+	}
+	condaShellStage := g.compileCondaShell(shellStage)
+
+	diffCondaEnvStage := llb.Diff(baseStage, condaEnvStage,
 		llb.WithCustomName("[internal] conda python environment"))
-	diffSystemStage := llb.Diff(shellStage, systemStage,
+	diffSystemStage := llb.Diff(baseStage, systemStage,
 		llb.WithCustomName("[internal] install system packages"))
+	diffShellStage := llb.Diff(baseStage, condaShellStage,
+		llb.WithCustomNamef("[internal] configure shell %s", g.Shell))
 	prePythonStage := llb.Merge([]llb.State{
 		diffSystemStage,
 		diffCondaEnvStage,
-		shellStage}, llb.WithCustomName("pre-python stage"))
+		diffShellStage,
+		baseStage}, llb.WithCustomName("pre-python stage"))
 
 	condaStage := llb.Diff(prePythonStage,
 		g.compileCondaPackages(prePythonStage),
 		llb.WithCustomName("[internal] install conda packages"))
 
+	pypiMirrorStage := g.compilePyPIIndex(prePythonStage)
+
 	pypiStage := llb.Diff(prePythonStage,
-		g.compilePyPIPackages(prePythonStage),
+		g.compilePyPIPackages(pypiMirrorStage),
 		llb.WithCustomName("[internal] install PyPI packages"))
 
 	vscodeStage, err := g.compileVSCode()

--- a/pkg/lang/ir/python.go
+++ b/pkg/lang/ir/python.go
@@ -49,10 +49,10 @@ func (g Graph) compilePython(baseStage llb.State) (llb.State, error) {
 	if err := g.compileJupyter(); err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile jupyter")
 	}
-	systemStage := g.compileSystemPackages(baseStage)
+	aptStage := g.compileUbuntuAPT(baseStage)
+	systemStage := g.compileSystemPackages(aptStage)
 
-	condaChannelStage := g.compileCondaChannel(baseStage)
-	condaEnvStage, err := g.compileCondaEnvironment(condaChannelStage)
+	condaEnvStage, err := g.compileCondaEnvironment(baseStage)
 	if err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile conda environment")
 	}
@@ -76,7 +76,9 @@ func (g Graph) compilePython(baseStage llb.State) (llb.State, error) {
 		diffShellStage,
 		baseStage}, llb.WithCustomName("pre-python stage"))
 
-	condaStage := llb.Diff(prePythonStage,
+	condaChannelStage := g.compileCondaChannel(prePythonStage)
+
+	condaStage := llb.Diff(condaChannelStage,
 		g.compileCondaPackages(prePythonStage),
 		llb.WithCustomName("[internal] install conda packages"))
 

--- a/pkg/lang/ir/python.go
+++ b/pkg/lang/ir/python.go
@@ -78,8 +78,8 @@ func (g Graph) compilePython(baseStage llb.State) (llb.State, error) {
 
 	condaChannelStage := g.compileCondaChannel(prePythonStage)
 
-	condaStage := llb.Diff(condaChannelStage,
-		g.compileCondaPackages(prePythonStage),
+	condaStage := llb.Diff(prePythonStage,
+		g.compileCondaPackages(condaChannelStage),
 		llb.WithCustomName("[internal] install conda packages"))
 
 	pypiMirrorStage := g.compilePyPIIndex(prePythonStage)

--- a/pkg/lang/ir/r.go
+++ b/pkg/lang/ir/r.go
@@ -22,10 +22,11 @@ import (
 	"github.com/moby/buildkit/client/llb"
 )
 
-func (g Graph) compileRLang(aptStage llb.State) (llb.State, error) {
+func (g Graph) compileRLang(baseStage llb.State) (llb.State, error) {
 	if err := g.compileJupyter(); err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile jupyter")
 	}
+	aptStage := g.compileUbuntuAPT(baseStage)
 	builtinSystemStage := aptStage
 
 	sshStage, err := g.copySSHKey(builtinSystemStage)


### PR DESCRIPTION
Ref #1103 

The software mirror configuration and shell configuration are delayed. Thus the conda cache will always work no matter with the shells and mirrors.

Signed-off-by: Ce Gao <cegao@tensorchord.ai>