### PR TITLE
fix: Fix zsh tab issue

### DIFF
--- a/pkg/app/debug_llb.go
+++ b/pkg/app/debug_llb.go
@@ -69,7 +69,7 @@ var CommandDebugLLB = &cli.Command{
 }
 
 func debugLLB(clicontext *cli.Context) error {
-	telemetry.GetReporter().Telemetry("debug-llb", nil)
+	telemetry.GetReporter().Telemetry("debug-llb")
 	opt, err := ParseBuildOpt(clicontext)
 	if err != nil {
 		return err

--- a/pkg/builder/util.go
+++ b/pkg/builder/util.go
@@ -42,9 +42,10 @@ func ImageConfigStr(labels map[string]string, ports map[string]struct{},
 	pl := platforms.Normalize(platforms.DefaultSpec())
 	img := v1.Image{
 		Config: v1.ImageConfig{
-			Labels:       labels,
-			WorkingDir:   "/",
-			Env:          append(env, "PATH="+DefaultPathEnv(pl.OS)),
+			Labels:     labels,
+			WorkingDir: "/",
+			Env: append(env,
+				"PATH="+DefaultPathEnv(pl.OS), "LC_ALL=en_US.UTF-8"),
 			ExposedPorts: ports,
 			Entrypoint:   entrypoint,
 		},

--- a/pkg/lang/ir/system.go
+++ b/pkg/lang/ir/system.go
@@ -156,6 +156,7 @@ func (g *Graph) preparePythonBase(root llb.State) llb.State {
 	sb.WriteString("&& rm -rf /var/lib/apt/lists/* ")
 	// shell prompt
 	sb.WriteString("&& curl --proto '=https' --tlsv1.2 -sSf https://starship.rs/install.sh | sh -s -- -y")
+	sb.WriteString("&& locale-gen en_US.UTF-8")
 
 	run := root.Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", sb.String())),
 		llb.WithCustomName("[internal] install built-in packages"))

--- a/pkg/types/envd.go
+++ b/pkg/types/envd.go
@@ -56,8 +56,8 @@ var BaseEnvironment = []struct {
 }{
 	{"DEBIAN_FRONTEND", "noninteractive"},
 	{"PATH", DefaultPathEnvUnix},
-	{"LANG", "C.UTF-8"},
-	{"LC_ALL", "C.UTF-8"},
+	{"LANG", "en_US.UTF-8"},
+	{"LC_ALL", "en_US.UTF-8"},
 }
 var BaseAptPackage = []string{
 	"bash-static",
@@ -81,6 +81,7 @@ var BaseAptPackage = []string{
 	"sudo",
 	"vim",
 	"zsh",
+	"locales",
 }
 
 type EnvdImage struct {


### PR DESCRIPTION
Close #183 

Test case:

```
def build():
    shell("zsh")
```

Before the PR:

```
~/golang via 🅒 envd 
⬢ [envd]❯ l<tab>

~/golang via 🅒 envd 
⬢ [envd]❯ l   l
l              ldconfig.real  LISTMAX        logger         lsblk          lzcmp        
la             ldd            ll             login          LS_COLORS      lzdiff       
langinfo       LESS           ln             logname        LSCOLORS       lzegrep      
last           let            local          LOGNAME        lscpu          lzfgrep   
```

After the PR:

```
~/golang via 🅒 envd 
⬢ [envd]❯ l<tab>
~/golang via 🅒 envd 
⬢ [envd]❯ l
l              ldconfig.real  LISTMAX        logger         lsblk          lzcmp        
la             ldd            ll             login          LS_COLORS      lzdiff       
langinfo       LESS           ln             logname        LSCOLORS       lzegrep      
last           let            local          LOGNAME        lscpu          lzfgrep   
```

Signed-off-by: Ce Gao <cegao@tensorchord.ai>