### PR TITLE
feat(github): add release template and labeler for pr

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+labels:
+  'bug':
+    - '\bfix'
+  'feature':
+    - '\bfeat'
+  'chore':
+    - '\bchore'
+  'document':
+    - '\bdoc[s]'
+  'refactor':
+    - '\brefact'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: Exciting New Features 🎉
+      labels:
+        - feature
+
+    - title: Bug Fix 🛠
+      labels:
+        - bug
+    
+    - title: Documentation 🖊️
+      labels:
+        - document
+
+    - title: Code Refactor 🏗️
+      labels:
+        - refactor
+
+    - title: Others
+      labels:
+        - chore    

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,16 @@
+name: pr labeler
+on: 
+  pull_request_target:
+    types: [opened]
+
+jobs:
+
+  labeler:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check Labels
+      id: labeler
+      uses: jimschubert/labeler-action@v2
+      with:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
close: #1140 

This is the first time I test a github workflow at a public repo. 
So I create [a repo](https://github.com/dqhl76/TestAction/tree/main/.github) which use the same config file to test and generate a [release changelog](https://github.com/dqhl76/TestAction/releases) as example. 

Signed-off-by: dqhl76 <dqhl76@gmail.com>
