### PR TITLE
chore: run as 1000:1000 for image cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,9 @@ jobs:
         username: ${{ secrets.DOCKERIO_USERNAME }}
         password: ${{ secrets.DOCKERIO_TOKEN }}
     - name: Build and push
-      run: ./base-images/remote-cache/build-and-push-remote-cache.sh
+      run: 
+        sudo -u runneradmin id
+        sudo -u runneradmin bash ./base-images/remote-cache/build-and-push-remote-cache.sh
       env:
         BUILD_FUNC: ${{ matrix.build_func }}
         TAG_SUFFIX: ${{ matrix.TAG_SUFFIX }}


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

The default uid in GitHub Actions is 1001.

![image](https://user-images.githubusercontent.com/12974685/201608307-9a31bcf2-2241-44e1-a5c6-da13f42e633d.png)

The `runneradmin` is 1000:1000.

![image](https://user-images.githubusercontent.com/12974685/201608402-60f99a6d-acd3-4726-8864-347dd6a3e360.png)

* close #1169 