### PR TITLE
feat: add name to `envd envs describe`

### DIFF
--- a/pkg/app/env_describe.go
+++ b/pkg/app/env_describe.go
@@ -15,8 +15,6 @@
 package app
 
 import (
-	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -24,8 +22,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
-
-	servertypes "github.com/tensorchord/envd-server/api/types"
 
 	"github.com/tensorchord/envd/pkg/envd"
 	"github.com/tensorchord/envd/pkg/home"
@@ -74,41 +70,14 @@ func getEnvironmentDescriptions(clicontext *cli.Context) error {
 		return errors.Wrap(err, "failed to list dependencies")
 	}
 
-	images, err := envdEngine.ListImage(clicontext.Context)
-	if err != nil {
-		return errors.Wrap(err, "Failed to list image")
-	}
-
-	var portMap = make(map[string]string)
-	for _, image := range images {
-		environmentPorts, err := parseEnvironmentPort(image.Labels[types.ImageLabelPorts])
-		if err != nil {
-			return errors.Wrap(err, "Error parsing environment ports")
-		}
-		for _, environmentPort := range environmentPorts {
-			portMap[fmt.Sprint(environmentPort.Port)] = environmentPort.Name
-		}
-	}
-
 	ports, err := envdEngine.ListEnvPortBinding(clicontext.Context, envName)
 	if err != nil {
 		return errors.Wrap(err, "failed to list port bindings")
 	}
 
-	for index, label := range ports {
-		label.Name = portMap[label.Port]
-		ports[index] = label
-	}
-
 	renderDependencies(os.Stdout, dep)
 	renderPortBindings(os.Stdout, ports)
 	return nil
-}
-
-func parseEnvironmentPort(lst string) ([]servertypes.EnvironmentPort, error) {
-	var pkgs []servertypes.EnvironmentPort
-	err := json.Unmarshal([]byte(lst), &pkgs)
-	return pkgs, err
 }
 
 func createTable(w io.Writer, headers []string) *tablewriter.Table {

--- a/pkg/envd/docker.go
+++ b/pkg/envd/docker.go
@@ -32,7 +32,6 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/sirupsen/logrus"
 
-	servertypes "github.com/tensorchord/envd-server/api/types"
 	envdconfig "github.com/tensorchord/envd/pkg/config"
 	"github.com/tensorchord/envd/pkg/lang/ir"
 	"github.com/tensorchord/envd/pkg/ssh"
@@ -193,30 +192,10 @@ func (e dockerEngine) ListEnvPortBinding(ctx context.Context, env string) ([]typ
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get container")
 	}
-	ports := types.NewPortBindingFromContainerJSON(ctr)
-	images, err := e.ListImage(ctx)
+
+	ports, err := types.NewPortBindingFromContainerJSON(ctr)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to list image")
-	}
-
-	var portMap = make(map[string]string)
-	for _, image := range images {
-		if strings.HasPrefix(image.Name, fmt.Sprintf("%s:", env)) {
-			var environmentPorts []servertypes.EnvironmentPort
-			err := json.Unmarshal([]byte(image.Labels[types.ImageLabelPorts]), &environmentPorts)
-			if err != nil {
-				return nil, errors.Wrap(err, "Error parsing environment ports")
-			}
-
-			for _, environmentPort := range environmentPorts {
-				portMap[fmt.Sprint(environmentPort.Port)] = environmentPort.Name
-			}
-		}
-	}
-
-	for index, label := range ports {
-		label.Name = portMap[label.Port]
-		ports[index] = label
+		return nil, errors.Wrap(err, "failed to get port binding from container json")
 	}
 
 	return ports, nil

--- a/pkg/envd/envdserver.go
+++ b/pkg/envd/envdserver.go
@@ -219,6 +219,7 @@ func (e *envdServerEngine) ListEnvPortBinding(
 	// TODO(gaocegege): Remove hard coded.
 	res := []types.PortBinding{
 		{
+			Name:     "ssh",
 			Port:     "2222",
 			Protocol: "TCP",
 			HostIP:   "localhost",

--- a/pkg/types/envd.go
+++ b/pkg/types/envd.go
@@ -279,7 +279,18 @@ func NewDependencyFromImageSummary(img types.ImageSummary) (*Dependency, error) 
 	return NewDependencyFromLabels(img.Labels)
 }
 
-func NewPortBindingFromContainerJSON(ctr types.ContainerJSON) []PortBinding {
+func NewPortBindingFromContainerJSON(ctr types.ContainerJSON) ([]PortBinding, error) {
+	var labels []servertypes.EnvironmentPort
+	err := json.Unmarshal([]byte(ctr.Config.Labels[ImageLabelPorts]), &labels)
+	if err != nil {
+		return nil, err
+	}
+
+	var portMap = make(map[string]string)
+	for _, label := range labels {
+		portMap[fmt.Sprint(label.Port)] = label.Name
+	}
+
 	config := ctr.HostConfig.PortBindings
 	var ports []PortBinding
 	for port, bindings := range config {
@@ -288,13 +299,15 @@ func NewPortBindingFromContainerJSON(ctr types.ContainerJSON) []PortBinding {
 		}
 		binding := bindings[len(bindings)-1]
 		ports = append(ports, PortBinding{
+			Name:     portMap[port.Port()],
 			Port:     port.Port(),
 			Protocol: port.Proto(),
 			HostIP:   binding.HostIP,
 			HostPort: binding.HostPort,
 		})
 	}
-	return ports
+
+	return ports, nil
 }
 
 func NewDependencyFromLabels(label map[string]string) (*Dependency, error) {

--- a/pkg/types/envd.go
+++ b/pkg/types/envd.go
@@ -152,6 +152,7 @@ type RepoInfo struct {
 }
 
 type PortBinding struct {
+	Name     string
 	Port     string
 	Protocol string
 	HostIP   string


### PR DESCRIPTION
Signed-off-by: AlexXi19 <alex2001314jjj@gmail.com>

https://github.com/tensorchord/envd/issues/551

Show service name in ports list as specified by the issue.  


### Testing 
Inspected `envd envs describe` for both jupyter notebook and R studio and verified that the names are correct. 
<img width="578" alt="image" src="https://user-images.githubusercontent.com/68758451/201868711-b737d887-6428-4105-b23b-70ca777150c2.png">

<img width="630" alt="image" src="https://user-images.githubusercontent.com/68758451/201868843-d95ebd81-5c4b-4324-85e2-4ea91ca54a0d.png">

