### PR TITLE
feat: merge coverage file and report to goverall

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -202,25 +202,29 @@ jobs:
       - name: Install bins
         run: |
           go install github.com/mattn/goveralls@latest
-          go install github.com/wadey/gocovmerge@latest
       - name: Get coverage report
         uses: actions/download-artifact@v3
         with:
           name: coverage-out
-          path: coverage.out
+          path: merge
+      
       - name: Get cli e2e coverage report
         uses: actions/download-artifact@v3
         with:
           name: e2e-cli-coverage-out
-          path: e2e-cli-coverage.out
+          path: merge
       - name: Get language e2e coverage report
         uses: actions/download-artifact@v3
         with:
           name: e2e-lang-coverage-out
-          path: e2e-lang-coverage.out
-      # - name: Send coverage
-      #   env:
-      #     COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     gocovmerge e2e-coverage.out coverage.out > final.out
-      #     goveralls -coverprofile=final.out -service=github
+          path: merge
+      - name: Merge all coverage reports
+        uses: cutecutecat/go-cover-merge@v1
+        with:
+          input_dir: merge
+          output_file: final.out
+      - name: Send coverage
+        env:
+          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          goveralls -coverprofile=final.out -service=github

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ e2e-test:
 		-X $(ROOT)/pkg/version.gitTreeState=$(GIT_TREE_STATE)                     \
 		-X $(ROOT)/pkg/version.gitTag="$(shell git describe --tags --abbrev=0)" \
 		-X $(ROOT)/pkg/version.developmentFlag=true" \
-		-race -v -timeout 20m -coverpkg=./pkg/app -coverprofile=e2e-coverage.out ./e2e
+		-race -v -timeout 20m -coverpkg=./pkg/... -coverprofile=e2e-coverage.out ./e2e
 
 
 e2e-cli-test:
@@ -193,7 +193,7 @@ e2e-cli-test:
 		-X $(ROOT)/pkg/version.gitTreeState=$(GIT_TREE_STATE)                     \
 		-X $(ROOT)/pkg/version.gitTag="$(shell git describe --tags --abbrev=0)" \
 		-X $(ROOT)/pkg/version.developmentFlag=true" \
-		-race -v -timeout 20m -coverpkg=./pkg/app -coverprofile=e2e-cli-coverage.out ./e2e/cli
+		-race -v -timeout 20m -coverpkg=./pkg/... -coverprofile=e2e-cli-coverage.out ./e2e/cli
 
 e2e-lang-test:
 	@go test -ldflags "-s -w -X $(ROOT)/pkg/version.version=$(VERSION) \
@@ -202,7 +202,7 @@ e2e-lang-test:
 		-X $(ROOT)/pkg/version.gitTreeState=$(GIT_TREE_STATE)                     \
 		-X $(ROOT)/pkg/version.gitTag="$(shell git describe --tags --abbrev=0)" \
 		-X $(ROOT)/pkg/version.developmentFlag=true" \
-		-race -v -timeout 20m -coverpkg=./pkg/app -coverprofile=e2e-lang-coverage.out ./e2e/language
+		-race -v -timeout 20m -coverpkg=./pkg/... -coverprofile=e2e-lang-coverage.out ./e2e/language
 
 e2e-doc-test:
 	@go test -ldflags "-s -w -X $(ROOT)/pkg/version.version=$(VERSION) \
@@ -211,7 +211,7 @@ e2e-doc-test:
 		-X $(ROOT)/pkg/version.gitTreeState=$(GIT_TREE_STATE)                     \
 		-X $(ROOT)/pkg/version.gitTag="$(shell git describe --tags --abbrev=0)" \
 		-X $(ROOT)/pkg/version.developmentFlag=true" \
-		-race -v -timeout 60m -coverpkg=./pkg/app -coverprofile=e2e-doc-coverage.out ./e2e/docs
+		-race -v -timeout 60m -coverpkg=./pkg/... -coverprofile=e2e-doc-coverage.out ./e2e/docs
 
 
 clean:  ## Clean the outputs and artifacts


### PR DESCRIPTION
Signed-off-by: cutecutecat <starkind1997@gmail.com>

The action [cutecutecat/go-cover-merge](https://github.com/cutecutecat/go-cover-merge) makes the wrapper of [gocovmerge](https://github.com/wadey/gocovmerge).

**Caution: `actions/download-artifact@v3` will create a directory of `path`, and put the actual artifact file inside that path when using argument `path`**
So:
```
- name: Get cli e2e coverage report
  uses: actions/download-artifact@v3
  with:
    name: e2e-cli-coverage-out
    path: e2e-cli-coverage.out
```
will lead to a path of `e2e-cli-coverage.out/e2e-cli-coverage.out`

will close #636 