### PR TITLE
chore: remove deprecated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ linters:
   enable:
     - gofmt
     - bodyclose
-    - deadcode
     - errcheck
     - goimports
     - errorlint
@@ -14,11 +13,9 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - typecheck
     - unparam
     - unused
-    - varcheck
 linters-settings:
   goimports:
     local-prefixes: github.com/tensorchord/envd/


### PR DESCRIPTION
This PR removes three linters which are deprecated and replaced by the `unused` linter.

```bash
➜  ~/github/envd git:(main) golangci-lint run --max-same-issues 0 --max-issues-per-linter 0
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```