### PR TITLE
feat: add option to output the completion script to terminal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,9 @@
 # to allow building multiple binaries. You are free to add more targets or change
 # existing implementations, as long as the semantics are preserved.
 #
-#   make              - default to 'build' target
+#   make              - default to 'build-local' target
 #   make lint         - code analysis
 #   make test         - run unit test (or plus integration test)
-#   make build        - alias to build-local target
 #   make build-local  - build local binary targets
 #   make build-linux  - build linux binary targets
 #   make container    - build containers

--- a/pkg/app/completion.go
+++ b/pkg/app/completion.go
@@ -15,6 +15,10 @@
 package app
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/cockroachdb/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -32,9 +36,28 @@ var CommandCompletion = &cli.Command{
 			Usage:   "Shell type to install completion",
 			Aliases: []string{"s"},
 		},
+		&cli.BoolFlag{
+			Name:  "no-install",
+			Usage: "Only output the completion script and don't install it",
+		},
 	},
 
 	Action: completion,
+}
+
+func handleCompletion(clicontext *cli.Context, installFunc func() error, outputFunc func() (string, error)) error {
+	if clicontext.Bool("no-install") {
+		script, err := outputFunc()
+		if err != nil {
+			return err
+		}
+		fmt.Println(script)
+	} else {
+		if err := installFunc(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func completion(clicontext *cli.Context) error {
@@ -42,18 +65,24 @@ func completion(clicontext *cli.Context) error {
 
 	n := len(shellList)
 	if n == 0 {
-		return errors.Errorf("at least one specified shell type")
+		defaultShell := os.Getenv("SHELL")
+		if defaultShell != "" {
+			shellList = append(shellList, filepath.Base(defaultShell))
+			n++
+		} else {
+			return errors.Errorf("Can't detect the default shell, please specify at least one shell type with --shell")
+		}
 	}
 
 	for i := 0; i < n; i++ {
 		logrus.Infof("[%d/%d] Add completion %s", i+1, n, shellList[i])
 		switch shellList[i] {
 		case "zsh":
-			if err := ac.InsertZSHCompleteEntry(); err != nil {
+			if err := handleCompletion(clicontext, ac.InsertZSHCompleteEntry, ac.ZshCompleteEntry); err != nil {
 				return err
 			}
 		case "bash":
-			if err := ac.InsertBashCompleteEntry(); err != nil {
+			if err := handleCompletion(clicontext, ac.InsertBashCompleteEntry, ac.BashCompleteEntry); err != nil {
 				return err
 			}
 		default:

--- a/pkg/autocomplete/bash.go
+++ b/pkg/autocomplete/bash.go
@@ -80,7 +80,7 @@ func InsertBashCompleteEntry() error {
 	}
 	defer f.Close()
 
-	bashEntry, err := bashCompleteEntry()
+	bashEntry, err := BashCompleteEntry()
 	if err != nil {
 		return errors.Wrapf(err, "unable to enable bash-completion")
 	}
@@ -92,6 +92,6 @@ func InsertBashCompleteEntry() error {
 	return nil
 }
 
-func bashCompleteEntry() (string, error) {
+func BashCompleteEntry() (string, error) {
 	return autocompleteBASH, nil
 }

--- a/pkg/autocomplete/zsh.go
+++ b/pkg/autocomplete/zsh.go
@@ -111,7 +111,7 @@ func InsertZSHCompleteEntry() error {
 	}
 	defer f.Close()
 
-	compEntry, err := zshCompleteEntry()
+	compEntry, err := ZshCompleteEntry()
 	if err != nil {
 		return errors.Wrapf(err, "Warning: unable to enable zsh-completion")
 	}
@@ -141,7 +141,7 @@ func InsertZSHCompleteEntry() error {
 	return deleteZcompdump()
 }
 
-func zshCompleteEntry() (string, error) {
+func ZshCompleteEntry() (string, error) {
 	return autocompleteZSH, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

* * *

I am adding a formula for envd to homebrew (https://github.com/Homebrew/homebrew-core/pull/118130). Homebrew can manage the autocompletion script, we only need to provide the completion script, without installing it. 

Add an option to `completion` command to output the script only.