### PR TITLE
docs: recommend one-line install script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Bootstrap:
 envd bootstrap
 ```
 
-Read the [documenation](https://envd.tensorchord.ai/guide/getting-started.html#install-and-bootstrap-envd) for more alternative installation methods.
+Read the [documentation](https://envd.tensorchord.ai/guide/getting-started.html#install-and-bootstrap-envd) for more alternative installation methods.
 
 > You can add `--dockerhub-mirror` or `-m` flag when running `envd bootstrap`, to configure the mirror for docker.io registry:
 >

--- a/README.md
+++ b/README.md
@@ -114,16 +114,16 @@ For example, the PyPI cache is shared across builds and thus the package will be
 `envd` can be installed with `pip`, or you can download the binary [release](https://github.com/tensorchord/envd/releases) directly. After the installation, please run `envd bootstrap` to bootstrap.
 
 ```bash
-# install with local pip
-pip install --pre --upgrade envd
+# install with one command
+curl -sSfL https://envd.tensorchord.ai/install.sh | sudo sh
 # or install with pipx
 pipx install envd --pip-args="--pre"
-# or download the latest release artifact with GitHub CLI
-bash -c "gh release download -R tensorchord/envd -p $(echo envd_\*_$(uname)_$(uname -p))"
 
 # bootstrap
 envd bootstrap
 ```
+
+Read the [documenation](https://envd.tensorchord.ai/guide/getting-started.html#install-and-bootstrap-envd) for more alternative installation methods.
 
 > You can add `--dockerhub-mirror` or `-m` flag when running `envd bootstrap`, to configure the mirror for docker.io registry:
 >

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For example, the PyPI cache is shared across builds and thus the package will be
 # install with one command
 curl -sSfL https://envd.tensorchord.ai/install.sh | sudo sh
 # or install with pipx
-pipx install envd --pip-args="--pre"
+pipx install envd
 
 # bootstrap
 envd bootstrap

--- a/README.md
+++ b/README.md
@@ -113,13 +113,15 @@ For example, the PyPI cache is shared across builds and thus the package will be
 
 `envd` can be installed with `pip`, or you can download the binary [release](https://github.com/tensorchord/envd/releases) directly. After the installation, please run `envd bootstrap` to bootstrap.
 
-```bash
-# install with one command
-curl -sSfL https://envd.tensorchord.ai/install.sh | sudo sh
-# or install with pipx
-pipx install envd
+One-line installation:
 
-# bootstrap
+```bash
+curl -sSfL https://envd.tensorchord.ai/install.sh | sudo bash
+```
+
+Bootstrap:
+
+```bash
 envd bootstrap
 ```
 


### PR DESCRIPTION
Signed-off-by: Frost Ming <mianghong@gmail.com>

* * *

As the install script is available on the website, we hereby change the most recommended installation method to it, because it doesn't depend on any software other than `curl` and should be considered the most beginner-friendly.