### PR TITLE
chore: disable interactive cli if no tty

### DIFF
--- a/e2e/v0/cli/init_test.go
+++ b/e2e/v0/cli/init_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	e2e "github.com/tensorchord/envd/e2e/v1"
+	"github.com/tensorchord/envd/pkg/app"
+	"github.com/tensorchord/envd/pkg/home"
+	"github.com/tensorchord/envd/pkg/util/fileutil"
+)
+
+var _ = Describe("init project", Ordered, func() {
+	var path string
+	BeforeAll(func() {
+		Expect(home.Initialize()).To(Succeed())
+		envdApp := app.New()
+		err := envdApp.Run([]string{"envd.test", "--debug", "bootstrap"})
+		Expect(err).To(Succeed())
+		e2e.ResetEnvdApp()
+		path, err = os.MkdirTemp("", "envd_init_test_*")
+		Expect(err).To(Succeed())
+		err = os.WriteFile(filepath.Join(path, "requirements.txt"), []byte("via"), 0666)
+		Expect(err).To(Succeed())
+	})
+
+	It("init python env", func() {
+		envdApp := app.New()
+		err := envdApp.Run([]string{"envd.test", "--debug", "init", "-p", path})
+		Expect(err).To(Succeed())
+		exist, err := fileutil.FileExists(filepath.Join(path, "build.envd"))
+		Expect(err).To(Succeed())
+		Expect(exist).To(BeTrue())
+	})
+
+	Describe("run init env", Ordered, func() {
+		var e *e2e.Example
+		BeforeAll(func() {
+			// have to use `path` inside ginkgo closure
+			e = e2e.NewExample(path, "init_test")
+			e.RunContainer()()
+		})
+		It("exec installed command inside container", func() {
+			_, err := e.Exec("via --help")
+			Expect(err).To(Succeed())
+			e.DestroyContainer()
+		})
+	})
+
+	AfterAll(func() {
+		os.RemoveAll(path)
+	})
+})

--- a/e2e/v1/cli/init_test.go
+++ b/e2e/v1/cli/init_test.go
@@ -1,0 +1,70 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	e2e "github.com/tensorchord/envd/e2e/v1"
+	"github.com/tensorchord/envd/pkg/app"
+	"github.com/tensorchord/envd/pkg/home"
+	"github.com/tensorchord/envd/pkg/util/fileutil"
+)
+
+var _ = Describe("init project", Ordered, func() {
+	var path string
+	BeforeAll(func() {
+		Expect(home.Initialize()).To(Succeed())
+		envdApp := app.New()
+		err := envdApp.Run([]string{"envd.test", "--debug", "bootstrap"})
+		Expect(err).To(Succeed())
+		e2e.ResetEnvdApp()
+		path, err = os.MkdirTemp("", "envd_init_test_*")
+		Expect(err).To(Succeed())
+		err = os.WriteFile(filepath.Join(path, "requirements.txt"), []byte("via"), 0666)
+		Expect(err).To(Succeed())
+	})
+
+	It("init python env", func() {
+		envdApp := app.New()
+		err := envdApp.Run([]string{"envd.test", "--debug", "init", "-p", path})
+		Expect(err).To(Succeed())
+		exist, err := fileutil.FileExists(filepath.Join(path, "build.envd"))
+		Expect(err).To(Succeed())
+		Expect(exist).To(BeTrue())
+	})
+
+	Describe("run init env", Ordered, func() {
+		var e *e2e.Example
+		BeforeAll(func() {
+			// have to use `path` inside ginkgo closure
+			e = e2e.NewExample(path, "init_test")
+			e.RunContainer()()
+		})
+		It("exec installed command inside container", func() {
+			_, err := e.Exec("via --help")
+			Expect(err).To(Succeed())
+			e.DestroyContainer()
+		})
+	})
+
+	AfterAll(func() {
+		os.RemoveAll(path)
+	})
+})

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -93,9 +93,10 @@ func InitPythonEnv(dir string) error {
 		return err
 	}
 
-	selectionMap[LabelPythonRequirement] = []string{requirements}
 	if len(requirements) == 0 {
 		startQuestion(PythonPackageChoice)
+	} else {
+		selectionMap[LabelPythonRequirement] = []string{requirements}
 	}
 	startQuestion(JupyterChoice)
 	return nil
@@ -124,7 +125,12 @@ func initCommand(clicontext *cli.Context) error {
 
 	if !isValidLang(lang) {
 		startQuestion(LanguageChoice)
-		lang = selectionMap[LabelLanguage][0]
+		if len(selectionMap[LabelLanguage]) > 0 {
+			lang = selectionMap[LabelLanguage][0]
+		} else {
+			lang = "python"
+			selectionMap[LabelLanguage][0] = lang
+		}
 	} else {
 		selectionMap[LabelLanguage] = []string{lang}
 	}
@@ -152,7 +158,7 @@ func initCommand(clicontext *cli.Context) error {
 	}
 
 	startQuestion(CudaChoice)
-	if selectionMap[LabelCudaChoice][0] == "Yes" {
+	if len(selectionMap[LabelCudaChoice]) > 0 && selectionMap[LabelCudaChoice][0] == "Yes" {
 		startQuestion(CudaVersionChoice)
 	}
 

--- a/pkg/app/init.go
+++ b/pkg/app/init.go
@@ -129,7 +129,7 @@ func initCommand(clicontext *cli.Context) error {
 			lang = selectionMap[LabelLanguage][0]
 		} else {
 			lang = "python"
-			selectionMap[LabelLanguage][0] = lang
+			selectionMap[LabelLanguage] = []string{lang}
 		}
 	} else {
 		selectionMap[LabelLanguage] = []string{lang}

--- a/pkg/app/interactive.go
+++ b/pkg/app/interactive.go
@@ -24,6 +24,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/cockroachdb/errors"
+	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -206,6 +207,11 @@ func (m model) addSelection() {
 }
 
 func startQuestion(input input) {
+	isTerminal := isatty.IsTerminal(os.Stdout.Fd())
+	if !isTerminal {
+		return
+	}
+
 	p := tea.NewProgram(InitModel(input))
 	m, err := p.Run()
 	if m.(model).exit {
@@ -228,7 +234,7 @@ func generateFile(clicontext *cli.Context) error {
 	if len(selectionMap[LabelCondaEnv]) > 0 {
 		buf.WriteString(fmt.Sprintf("%sinstall.conda_packages(env_file=\"%s\")\n", indentation, selectionMap[LabelCondaEnv][0]))
 	}
-	if selectionMap[LabelCudaChoice][0] == "Yes" {
+	if len(selectionMap[LabelCudaChoice]) > 0 && selectionMap[LabelCudaChoice][0] == "Yes" {
 		buf.WriteString(fmt.Sprintf("%scuda(version=\"%s\", cudann=\"8\")\n", indentation, selectionMap[LabelCuda][0]))
 	}
 	if len(selectionMap[LabelJupyterChoice]) > 0 && selectionMap[LabelJupyterChoice][0] == "Yes" {


### PR DESCRIPTION
Pull request to address build failing [here](https://github.com/Homebrew/homebrew-core/pull/118300) and other CI contexts. 

Uses the [go-isatty](https://github.com/mattn/go-isatty) package to detect terminal and disable interactive cli if terminal doesn't exist. 

If terminal doesn't exist, the default `build.envd` generated is: 

```python 
def build():
    base(os="ubuntu20.04", language="python")
```

Added back previously removed cli init tests. 