### PR TITLE
feat: add --format for commands to output json

### DIFF
--- a/pkg/app/context_ls.go
+++ b/pkg/app/context_ls.go
@@ -15,18 +15,15 @@
 package app
 
 import (
-	"fmt"
-	"io"
 	"os"
 
 	"github.com/cockroachdb/errors"
-	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 
 	"github.com/tensorchord/envd/pkg/app/formatter"
 	"github.com/tensorchord/envd/pkg/app/formatter/json"
+	"github.com/tensorchord/envd/pkg/app/formatter/table"
 	"github.com/tensorchord/envd/pkg/home"
-	"github.com/tensorchord/envd/pkg/types"
 )
 
 var CommandContextList = &cli.Command{
@@ -46,43 +43,9 @@ func contextList(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		renderContext(os.Stdout, contexts)
+		table.RenderContext(os.Stdout, contexts)
 	case "json":
 		return json.PrintContext(contexts)
 	}
 	return nil
-}
-
-func renderContext(w io.Writer, contexts types.EnvdContext) {
-	table := tablewriter.NewWriter(w)
-	table.SetHeader([]string{"context", "builder", "builder addr", "runner", "runner addr"})
-
-	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetCenterSeparator("")
-	table.SetColumnSeparator("")
-	table.SetRowSeparator("")
-	table.SetHeaderLine(false)
-	table.SetBorder(false)
-	table.SetTablePadding("\t") // pad with tabs
-	table.SetNoWhiteSpace(true)
-
-	for _, p := range contexts.Contexts {
-		envRow := make([]string, 5)
-		if p.Name == contexts.Current {
-			envRow[0] = fmt.Sprintf("%s (current)", p.Name)
-		} else {
-			envRow[0] = p.Name
-		}
-		envRow[1] = string(p.Builder)
-		envRow[2] = fmt.Sprintf("%s://%s", p.Builder, p.BuilderAddress)
-		envRow[3] = string(p.Runner)
-		if p.RunnerAddress != nil {
-			envRow[4] = stringOrNone(*p.RunnerAddress)
-		}
-		table.Append(envRow)
-	}
-	table.Render()
 }

--- a/pkg/app/env_ls.go
+++ b/pkg/app/env_ls.go
@@ -19,12 +19,13 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/app/formatter/json"
 	"github.com/tensorchord/envd/pkg/app/telemetry"
 	"github.com/tensorchord/envd/pkg/envd"
 	"github.com/tensorchord/envd/pkg/home"
@@ -36,22 +37,7 @@ var CommandListEnv = &cli.Command{
 	Aliases: []string{"ls", "l"},
 	Usage:   "List envd environments",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:     "format",
-			Usage:    "Format of output, could be \"json\" or \"table\"",
-			Aliases:  []string{"f"},
-			Value:    "table",
-			Required: false,
-			Action: func(clicontext *cli.Context, v string) error {
-				switch v {
-				case
-					"table",
-					"json":
-					return nil
-				}
-				return errors.Errorf("Argument format only allows \"json\" and \"table\", found %v", v)
-			},
-		},
+		&formatter.FormatFlag,
 	},
 	Action: getEnvironment,
 }
@@ -77,14 +63,14 @@ func getEnvironment(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		renderTableEnvironments(os.Stdout, envs)
+		renderEnvironments(os.Stdout, envs)
 	case "json":
-		return renderjsonEnvironments(envs)
+		return json.PrintEnvironments(envs)
 	}
 	return nil
 }
 
-func renderTableEnvironments(w io.Writer, envs []types.EnvdEnvironment) {
+func renderEnvironments(w io.Writer, envs []types.EnvdEnvironment) {
 	table := tablewriter.NewWriter(w)
 	table.SetHeader([]string{
 		"Name", "Endpoint", "SSH Target", "Image",
@@ -106,7 +92,7 @@ func renderTableEnvironments(w io.Writer, envs []types.EnvdEnvironment) {
 	for _, env := range envs {
 		envRow := make([]string, 9)
 		envRow[0] = env.Name
-		envRow[1] = endpointOrNone(env)
+		envRow[1] = formatter.FormatEndpoint(env)
 		envRow[2] = fmt.Sprintf("%s.envd", env.Name)
 		envRow[3] = env.Spec.Image
 		envRow[4] = strconv.FormatBool(env.GPU)
@@ -116,44 +102,4 @@ func renderTableEnvironments(w io.Writer, envs []types.EnvdEnvironment) {
 		table.Append(envRow)
 	}
 	table.Render()
-}
-
-type envJsonDisplay struct {
-	Name      string `json:"name"`
-	Endpoint  string `json:"endpoint,omitempty"`
-	SSHTarget string `json:"ssh_target"`
-	Image     string `json:"image"`
-	GPU       bool   `json:"gpu"`
-	CUDA      string `json:"cuda,omitempty"`
-	CUDNN     string `json:"cudnn,omitempty"`
-	Status    string `json:"status"`
-}
-
-func renderjsonEnvironments(envs []types.EnvdEnvironment) error {
-	output := []envJsonDisplay{}
-	for _, env := range envs {
-		item := envJsonDisplay{
-			Name:      env.Name,
-			Endpoint:  endpointOrNone(env),
-			SSHTarget: fmt.Sprintf("%s.envd", env.Name),
-			Image:     env.Spec.Image,
-			GPU:       env.GPU,
-			CUDA:      env.CUDA,
-			CUDNN:     env.CUDNN,
-			Status:    env.Status.Phase,
-		}
-		output = append(output, item)
-	}
-	return PrintJson(output)
-}
-
-func endpointOrNone(env types.EnvdEnvironment) string {
-	var res strings.Builder
-	if env.Status.JupyterAddr != nil {
-		res.WriteString(fmt.Sprintf("jupyter: %s", *env.Status.JupyterAddr))
-	}
-	if env.Status.RStudioServerAddr != nil {
-		res.WriteString(fmt.Sprintf("rstudio: %s", *env.Status.RStudioServerAddr))
-	}
-	return res.String()
 }

--- a/pkg/app/env_ls.go
+++ b/pkg/app/env_ls.go
@@ -15,21 +15,17 @@
 package app
 
 import (
-	"fmt"
-	"io"
 	"os"
-	"strconv"
 
 	"github.com/cockroachdb/errors"
-	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 
 	"github.com/tensorchord/envd/pkg/app/formatter"
 	"github.com/tensorchord/envd/pkg/app/formatter/json"
+	"github.com/tensorchord/envd/pkg/app/formatter/table"
 	"github.com/tensorchord/envd/pkg/app/telemetry"
 	"github.com/tensorchord/envd/pkg/envd"
 	"github.com/tensorchord/envd/pkg/home"
-	"github.com/tensorchord/envd/pkg/types"
 )
 
 var CommandListEnv = &cli.Command{
@@ -63,43 +59,9 @@ func getEnvironment(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		renderEnvironments(os.Stdout, envs)
+		table.RenderEnvironments(os.Stdout, envs)
 	case "json":
 		return json.PrintEnvironments(envs)
 	}
 	return nil
-}
-
-func renderEnvironments(w io.Writer, envs []types.EnvdEnvironment) {
-	table := tablewriter.NewWriter(w)
-	table.SetHeader([]string{
-		"Name", "Endpoint", "SSH Target", "Image",
-		"GPU", "CUDA", "CUDNN", "Status",
-	})
-
-	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(true)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetCenterSeparator("")
-	table.SetColumnSeparator("")
-	table.SetRowSeparator("")
-	table.SetHeaderLine(false)
-	table.SetBorder(false)
-	table.SetTablePadding("\t") // pad with tabs
-	table.SetNoWhiteSpace(true)
-
-	for _, env := range envs {
-		envRow := make([]string, 9)
-		envRow[0] = env.Name
-		envRow[1] = formatter.FormatEndpoint(env)
-		envRow[2] = fmt.Sprintf("%s.envd", env.Name)
-		envRow[3] = env.Spec.Image
-		envRow[4] = strconv.FormatBool(env.GPU)
-		envRow[5] = stringOrNone(env.CUDA)
-		envRow[6] = stringOrNone(env.CUDNN)
-		envRow[7] = env.Status.Phase
-		table.Append(envRow)
-	}
-	table.Render()
 }

--- a/pkg/app/formatter/data.go
+++ b/pkg/app/formatter/data.go
@@ -17,7 +17,9 @@ package formatter
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/docker/go-units"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
@@ -106,4 +108,21 @@ func GetRuntimes(info *types.EnvdInfo) string {
 		keys = append(keys, k)
 	}
 	return "[" + strings.Join(keys, ",") + "]"
+}
+
+func StringOrNone(target string) string {
+	if target == "" {
+		return "<none>"
+	}
+	return target
+}
+
+func CreatedSinceString(created int64) string {
+	createdAt := time.Unix(created, 0)
+
+	if createdAt.IsZero() {
+		return ""
+	}
+
+	return units.HumanDuration(time.Now().UTC().Sub(createdAt)) + " ago"
 }

--- a/pkg/app/formatter/data.go
+++ b/pkg/app/formatter/data.go
@@ -1,0 +1,109 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package formatter
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+
+	"github.com/tensorchord/envd/pkg/envd"
+	"github.com/tensorchord/envd/pkg/home"
+	"github.com/tensorchord/envd/pkg/types"
+)
+
+var FormatFlag = cli.StringFlag{
+	Name:     "format",
+	Usage:    "Format of output, could be \"json\" or \"table\", could be \"json\" or \"table\"",
+	Aliases:  []string{"p"},
+	Value:    "table",
+	Required: false,
+	Action:   formatterValidator,
+}
+
+func formatterValidator(clicontext *cli.Context, v string) error {
+	switch v {
+	case
+		"table",
+		"json":
+		return nil
+	}
+	return errors.Errorf("Argument format only allows \"json\" and \"table\", found \"%v\"", v)
+}
+
+func FormatEndpoint(env types.EnvdEnvironment) string {
+	var res strings.Builder
+	if env.Status.JupyterAddr != nil {
+		res.WriteString(fmt.Sprintf("jupyter: %s", *env.Status.JupyterAddr))
+	}
+	if env.Status.RStudioServerAddr != nil {
+		res.WriteString(fmt.Sprintf("rstudio: %s", *env.Status.RStudioServerAddr))
+	}
+	return res.String()
+}
+
+func GetDetailedVersion(clicontext *cli.Context) (DetailedVersion, error) {
+	context, err := home.GetManager().ContextGetCurrent()
+	if err != nil {
+		return DetailedVersion{}, errors.Wrap(err, "failed to get the current context")
+	}
+	opt := envd.Options{
+		Context: context,
+	}
+	engine, err := envd.New(clicontext.Context, opt)
+	if err != nil {
+		return DetailedVersion{}, errors.Wrap(
+			err, "failed to create engine for docker server",
+		)
+	}
+
+	info, err := engine.GetInfo(clicontext.Context)
+	if err != nil {
+		return DetailedVersion{}, errors.Wrap(
+			err, "failed to get detailed version info from docker server",
+		)
+	}
+
+	return DetailedVersion{
+		OSVersion:         info.OSVersion,
+		OSType:            info.OSType,
+		KernelVersion:     info.KernelVersion,
+		DockerVersion:     info.ServerVersion,
+		Architecture:      info.Architecture,
+		DefaultRuntime:    info.DefaultRuntime,
+		ContainerRuntimes: GetRuntimes(info),
+	}, nil
+}
+
+type DetailedVersion struct {
+	OSVersion         string
+	OSType            string
+	KernelVersion     string
+	Architecture      string
+	DockerVersion     string
+	ContainerRuntimes string
+	DefaultRuntime    string
+}
+
+func GetRuntimes(info *types.EnvdInfo) string {
+	runtimesMap := info.Runtimes
+	keys := make([]string, 0, len(runtimesMap))
+	for k := range runtimesMap {
+		keys = append(keys, k)
+	}
+	return "[" + strings.Join(keys, ",") + "]"
+}

--- a/pkg/app/formatter/data.go
+++ b/pkg/app/formatter/data.go
@@ -30,8 +30,8 @@ import (
 
 var FormatFlag = cli.StringFlag{
 	Name:     "format",
-	Usage:    "Format of output, could be \"json\" or \"table\", could be \"json\" or \"table\"",
-	Aliases:  []string{"p"},
+	Usage:    `Format of output, could be "json" or "table"`,
+	Aliases:  []string{"f"},
 	Value:    "table",
 	Required: false,
 	Action:   formatterValidator,
@@ -44,7 +44,7 @@ func formatterValidator(clicontext *cli.Context, v string) error {
 		"json":
 		return nil
 	}
-	return errors.Errorf("Argument format only allows \"json\" and \"table\", found \"%v\"", v)
+	return errors.Errorf(`Argument format only allows "json" and "table", found "%v"`, v)
 }
 
 func FormatEndpoint(env types.EnvdEnvironment) string {

--- a/pkg/app/formatter/json/context.go
+++ b/pkg/app/formatter/json/context.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tensorchord/envd/pkg/types"
 )
 
-type contextJsonInfo struct {
+type contextJSONInfo struct {
 	Context     string `json:"context"`
 	Builder     string `json:"builder"`
 	BuilderAddr string `json:"builder_addr"`
@@ -30,9 +30,9 @@ type contextJsonInfo struct {
 }
 
 func PrintContext(contexts types.EnvdContext) error {
-	output := []contextJsonInfo{}
+	output := []contextJSONInfo{}
 	for _, p := range contexts.Contexts {
-		item := contextJsonInfo{
+		item := contextJSONInfo{
 			Context:     p.Name,
 			Builder:     string(p.Builder),
 			BuilderAddr: fmt.Sprintf("%s://%s", p.Builder, p.BuilderAddress),
@@ -44,5 +44,5 @@ func PrintContext(contexts types.EnvdContext) error {
 		}
 		output = append(output, item)
 	}
-	return printJson(output)
+	return printJSON(output)
 }

--- a/pkg/app/formatter/json/context.go
+++ b/pkg/app/formatter/json/context.go
@@ -20,7 +20,7 @@ import (
 	"github.com/tensorchord/envd/pkg/types"
 )
 
-type contextJSONInfo struct {
+type contextInfo struct {
 	Context     string `json:"context"`
 	Builder     string `json:"builder"`
 	BuilderAddr string `json:"builder_addr"`
@@ -30,9 +30,9 @@ type contextJSONInfo struct {
 }
 
 func PrintContext(contexts types.EnvdContext) error {
-	output := []contextJSONInfo{}
+	output := []contextInfo{}
 	for _, p := range contexts.Contexts {
-		item := contextJSONInfo{
+		item := contextInfo{
 			Context:     p.Name,
 			Builder:     string(p.Builder),
 			BuilderAddr: fmt.Sprintf("%s://%s", p.Builder, p.BuilderAddress),

--- a/pkg/app/formatter/json/context.go
+++ b/pkg/app/formatter/json/context.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"fmt"
+
+	"github.com/tensorchord/envd/pkg/types"
+)
+
+type contextJsonInfo struct {
+	Context     string `json:"context"`
+	Builder     string `json:"builder"`
+	BuilderAddr string `json:"builder_addr"`
+	Runner      string `json:"runner"`
+	RunnerAddr  string `json:"runner_addr,omitempty"`
+	Current     bool   `json:"current"`
+}
+
+func PrintContext(contexts types.EnvdContext) error {
+	output := []contextJsonInfo{}
+	for _, p := range contexts.Contexts {
+		item := contextJsonInfo{
+			Context:     p.Name,
+			Builder:     string(p.Builder),
+			BuilderAddr: fmt.Sprintf("%s://%s", p.Builder, p.BuilderAddress),
+			Runner:      string(p.Runner),
+			Current:     p.Name == contexts.Current,
+		}
+		if p.RunnerAddress != nil {
+			item.RunnerAddr = *p.RunnerAddress
+		}
+		output = append(output, item)
+	}
+	return printJson(output)
+}

--- a/pkg/app/formatter/json/env.go
+++ b/pkg/app/formatter/json/env.go
@@ -1,0 +1,98 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"fmt"
+
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/types"
+)
+
+type envJsonLs struct {
+	Name      string `json:"name"`
+	Endpoint  string `json:"endpoint,omitempty"`
+	SSHTarget string `json:"ssh_target"`
+	Image     string `json:"image"`
+	GPU       bool   `json:"gpu"`
+	CUDA      string `json:"cuda,omitempty"`
+	CUDNN     string `json:"cudnn,omitempty"`
+	Status    string `json:"status"`
+}
+
+func PrintEnvironments(envs []types.EnvdEnvironment) error {
+	output := []envJsonLs{}
+	for _, env := range envs {
+		item := envJsonLs{
+			Name:      env.Name,
+			Endpoint:  formatter.FormatEndpoint(env),
+			SSHTarget: fmt.Sprintf("%s.envd", env.Name),
+			Image:     env.Spec.Image,
+			GPU:       env.GPU,
+			CUDA:      env.CUDA,
+			CUDNN:     env.CUDNN,
+			Status:    env.Status.Phase,
+		}
+		output = append(output, item)
+	}
+	return printJson(output)
+}
+
+type envJsonDescribe struct {
+	Ports        []envJsonPort       `json:"ports,omitempty"`
+	Dependencies []envJsonDependency `json:"dependencies,omitempty"`
+}
+type envJsonPort struct {
+	Name          string `json:"name"`
+	ContainerPort string `json:"container_port"`
+	Protocol      string `json:"protocol"`
+	HostIP        string `json:"host_ip"`
+	HostPort      string `json:"host_port"`
+}
+
+type envJsonDependency struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+func PrintEnvironmentDescriptions(dep *types.Dependency, ports []types.PortBinding) error {
+	output := envJsonDescribe{}
+
+	for _, port := range ports {
+		port := envJsonPort{
+			Name:          port.Name,
+			ContainerPort: port.Port,
+			Protocol:      port.Protocol,
+			HostIP:        port.HostIP,
+			HostPort:      port.HostPort,
+		}
+		output.Ports = append(output.Ports, port)
+	}
+	for _, p := range dep.PyPIPackages {
+		dependency := envJsonDependency{
+			Name: p,
+			Type: "Python",
+		}
+		output.Dependencies = append(output.Dependencies, dependency)
+	}
+	for _, p := range dep.APTPackages {
+		dependency := envJsonDependency{
+			Name: p,
+			Type: "APT",
+		}
+		output.Dependencies = append(output.Dependencies, dependency)
+	}
+	return printJson(output)
+}

--- a/pkg/app/formatter/json/env.go
+++ b/pkg/app/formatter/json/env.go
@@ -21,7 +21,7 @@ import (
 	"github.com/tensorchord/envd/pkg/types"
 )
 
-type envJSONLs struct {
+type envInfo struct {
 	Name      string `json:"name"`
 	Endpoint  string `json:"endpoint,omitempty"`
 	SSHTarget string `json:"ssh_target"`
@@ -33,9 +33,9 @@ type envJSONLs struct {
 }
 
 func PrintEnvironments(envs []types.EnvdEnvironment) error {
-	output := []envJSONLs{}
+	output := []envInfo{}
 	for _, env := range envs {
-		item := envJSONLs{
+		item := envInfo{
 			Name:      env.Name,
 			Endpoint:  formatter.FormatEndpoint(env),
 			SSHTarget: fmt.Sprintf("%s.envd", env.Name),
@@ -50,11 +50,11 @@ func PrintEnvironments(envs []types.EnvdEnvironment) error {
 	return printJSON(output)
 }
 
-type envJSONDescribe struct {
-	Ports        []envJSONPort       `json:"ports,omitempty"`
-	Dependencies []envJSONDependency `json:"dependencies,omitempty"`
+type envDescribe struct {
+	Ports        []envPort       `json:"ports,omitempty"`
+	Dependencies []envDependency `json:"dependencies,omitempty"`
 }
-type envJSONPort struct {
+type envPort struct {
 	Name          string `json:"name"`
 	ContainerPort string `json:"container_port"`
 	Protocol      string `json:"protocol"`
@@ -62,16 +62,16 @@ type envJSONPort struct {
 	HostPort      string `json:"host_port"`
 }
 
-type envJSONDependency struct {
+type envDependency struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
 func PrintEnvironmentDescriptions(dep *types.Dependency, ports []types.PortBinding) error {
-	output := envJSONDescribe{}
+	output := envDescribe{}
 
 	for _, port := range ports {
-		port := envJSONPort{
+		port := envPort{
 			Name:          port.Name,
 			ContainerPort: port.Port,
 			Protocol:      port.Protocol,
@@ -81,14 +81,14 @@ func PrintEnvironmentDescriptions(dep *types.Dependency, ports []types.PortBindi
 		output.Ports = append(output.Ports, port)
 	}
 	for _, p := range dep.PyPIPackages {
-		dependency := envJSONDependency{
+		dependency := envDependency{
 			Name: p,
 			Type: "Python",
 		}
 		output.Dependencies = append(output.Dependencies, dependency)
 	}
 	for _, p := range dep.APTPackages {
-		dependency := envJSONDependency{
+		dependency := envDependency{
 			Name: p,
 			Type: "APT",
 		}

--- a/pkg/app/formatter/json/env.go
+++ b/pkg/app/formatter/json/env.go
@@ -21,7 +21,7 @@ import (
 	"github.com/tensorchord/envd/pkg/types"
 )
 
-type envJsonLs struct {
+type envJSONLs struct {
 	Name      string `json:"name"`
 	Endpoint  string `json:"endpoint,omitempty"`
 	SSHTarget string `json:"ssh_target"`
@@ -33,9 +33,9 @@ type envJsonLs struct {
 }
 
 func PrintEnvironments(envs []types.EnvdEnvironment) error {
-	output := []envJsonLs{}
+	output := []envJSONLs{}
 	for _, env := range envs {
-		item := envJsonLs{
+		item := envJSONLs{
 			Name:      env.Name,
 			Endpoint:  formatter.FormatEndpoint(env),
 			SSHTarget: fmt.Sprintf("%s.envd", env.Name),
@@ -47,14 +47,14 @@ func PrintEnvironments(envs []types.EnvdEnvironment) error {
 		}
 		output = append(output, item)
 	}
-	return printJson(output)
+	return printJSON(output)
 }
 
-type envJsonDescribe struct {
-	Ports        []envJsonPort       `json:"ports,omitempty"`
-	Dependencies []envJsonDependency `json:"dependencies,omitempty"`
+type envJSONDescribe struct {
+	Ports        []envJSONPort       `json:"ports,omitempty"`
+	Dependencies []envJSONDependency `json:"dependencies,omitempty"`
 }
-type envJsonPort struct {
+type envJSONPort struct {
 	Name          string `json:"name"`
 	ContainerPort string `json:"container_port"`
 	Protocol      string `json:"protocol"`
@@ -62,16 +62,16 @@ type envJsonPort struct {
 	HostPort      string `json:"host_port"`
 }
 
-type envJsonDependency struct {
+type envJSONDependency struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
 }
 
 func PrintEnvironmentDescriptions(dep *types.Dependency, ports []types.PortBinding) error {
-	output := envJsonDescribe{}
+	output := envJSONDescribe{}
 
 	for _, port := range ports {
-		port := envJsonPort{
+		port := envJSONPort{
 			Name:          port.Name,
 			ContainerPort: port.Port,
 			Protocol:      port.Protocol,
@@ -81,18 +81,18 @@ func PrintEnvironmentDescriptions(dep *types.Dependency, ports []types.PortBindi
 		output.Ports = append(output.Ports, port)
 	}
 	for _, p := range dep.PyPIPackages {
-		dependency := envJsonDependency{
+		dependency := envJSONDependency{
 			Name: p,
 			Type: "Python",
 		}
 		output.Dependencies = append(output.Dependencies, dependency)
 	}
 	for _, p := range dep.APTPackages {
-		dependency := envJsonDependency{
+		dependency := envJSONDependency{
 			Name: p,
 			Type: "APT",
 		}
 		output.Dependencies = append(output.Dependencies, dependency)
 	}
-	return printJson(output)
+	return printJSON(output)
 }

--- a/pkg/app/formatter/json/image.go
+++ b/pkg/app/formatter/json/image.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tensorchord/envd/pkg/types"
 )
 
-type imgJSONInfo struct {
+type imgInfo struct {
 	Name    string `json:"name"`
 	Context string `json:"endpoint,omitempty"`
 	GPU     bool   `json:"gpu"`
@@ -35,10 +35,10 @@ type imgJSONInfo struct {
 }
 
 func PrintImages(imgs []types.EnvdImage) error {
-	output := []imgJSONInfo{}
+	output := []imgInfo{}
 	for _, img := range imgs {
 		CreatedAt := time.Unix(img.Created, 0)
-		item := imgJSONInfo{
+		item := imgInfo{
 			Name:    img.Name,
 			Context: img.BuildContext,
 			GPU:     img.GPU,

--- a/pkg/app/formatter/json/image.go
+++ b/pkg/app/formatter/json/image.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tensorchord/envd/pkg/types"
 )
 
-type imgJsonInfo struct {
+type imgJSONInfo struct {
 	Name    string `json:"name"`
 	Context string `json:"endpoint,omitempty"`
 	GPU     bool   `json:"gpu"`
@@ -35,10 +35,10 @@ type imgJsonInfo struct {
 }
 
 func PrintImages(imgs []types.EnvdImage) error {
-	output := []imgJsonInfo{}
+	output := []imgJSONInfo{}
 	for _, img := range imgs {
 		CreatedAt := time.Unix(img.Created, 0)
-		item := imgJsonInfo{
+		item := imgJSONInfo{
 			Name:    img.Name,
 			Context: img.BuildContext,
 			GPU:     img.GPU,
@@ -50,5 +50,5 @@ func PrintImages(imgs []types.EnvdImage) error {
 		}
 		output = append(output, item)
 	}
-	return printJson(output)
+	return printJSON(output)
 }

--- a/pkg/app/formatter/json/image.go
+++ b/pkg/app/formatter/json/image.go
@@ -1,0 +1,54 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"time"
+
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/go-units"
+
+	"github.com/tensorchord/envd/pkg/types"
+)
+
+type imgJsonInfo struct {
+	Name    string `json:"name"`
+	Context string `json:"endpoint,omitempty"`
+	GPU     bool   `json:"gpu"`
+	CUDA    string `json:"cuda,omitempty"`
+	CUDNN   string `json:"cudnn,omitempty"`
+	ImageID string `json:"image_id"`
+	Created string `json:"created"`
+	Size    string `json:"size"`
+}
+
+func PrintImages(imgs []types.EnvdImage) error {
+	output := []imgJsonInfo{}
+	for _, img := range imgs {
+		CreatedAt := time.Unix(img.Created, 0)
+		item := imgJsonInfo{
+			Name:    img.Name,
+			Context: img.BuildContext,
+			GPU:     img.GPU,
+			CUDA:    img.CUDA,
+			CUDNN:   img.CUDNN,
+			ImageID: stringid.TruncateID(img.Digest),
+			Created: units.HumanDuration(time.Now().UTC().Sub(CreatedAt)),
+			Size:    units.HumanSizeWithPrecision(float64(img.Size), 3),
+		}
+		output = append(output, item)
+	}
+	return printJson(output)
+}

--- a/pkg/app/formatter/json/print.go
+++ b/pkg/app/formatter/json/print.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func printJson(v any) error {
+func printJSON(v any) error {
 	buffer := &bytes.Buffer{}
 	encoder := json.NewEncoder(buffer)
 	// avoid escaped from <none> into "\u003cnone\u003e"

--- a/pkg/app/formatter/json/print.go
+++ b/pkg/app/formatter/json/print.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+func printJson(v any) error {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	// avoid escaped from <none> into "\u003cnone\u003e"
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(v)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal json")
+	}
+	fmt.Print(buffer.String())
+	return nil
+}

--- a/pkg/app/formatter/json/version.go
+++ b/pkg/app/formatter/json/version.go
@@ -1,0 +1,78 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package json
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/version"
+)
+
+type versionJson struct {
+	Envd              string `json:"envd"`
+	BuildDate         string `json:"build_date,omitempty"`
+	GitCommit         string `json:"git_commit,omitempty"`
+	GitTreeState      string `json:"git_tree_state,omitempty"`
+	GitTag            string `json:"git_tag,omitempty"`
+	GoVersion         string `json:"go_version,omitempty"`
+	Compiler          string `json:"compiler,omitempty"`
+	Platform          string `json:"platform,omitempty"`
+	OSType            string `json:"os_type,omitempty"`
+	OSVersion         string `json:"os_version,omitempty"`
+	KernelVersion     string `json:"kernel_version,omitempty"`
+	DockerHostVersion string `json:"docker_host_version,omitempty"`
+	ContainerRuntimes string `json:"container_runtimes,omitempty"`
+	DefaultRuntime    string `json:"default_runtime,omitempty"`
+}
+
+func PrintVersion(clicontext *cli.Context) error {
+	short := clicontext.Bool("short")
+	detail := clicontext.Bool("detail")
+	ver := version.GetVersion()
+	detailVer, err := formatter.GetDetailedVersion(clicontext)
+	output := versionJson{
+		Envd: version.GetVersion().String(),
+	}
+	if short {
+		return printJson(output)
+	}
+	output.BuildDate = ver.BuildDate
+	output.GitCommit = ver.GitCommit
+	output.GitTreeState = ver.GitTreeState
+	if ver.GitTag != "" {
+		output.GitTag = ver.GitTag
+	}
+	output.GoVersion = ver.GoVersion
+	output.Compiler = ver.Compiler
+	output.Platform = ver.Platform
+	if detail {
+		if err != nil {
+			fmt.Printf("Error in getting details from Docker Server: %s\n", err)
+		} else {
+			output.OSType = detailVer.OSType
+			if detailVer.OSVersion != "" {
+				output.OSVersion = detailVer.OSVersion
+			}
+			output.KernelVersion = detailVer.KernelVersion
+			output.DockerHostVersion = detailVer.DockerVersion
+			output.ContainerRuntimes = detailVer.ContainerRuntimes
+			output.DefaultRuntime = detailVer.DefaultRuntime
+		}
+	}
+	return printJson(output)
+}

--- a/pkg/app/formatter/json/version.go
+++ b/pkg/app/formatter/json/version.go
@@ -23,7 +23,7 @@ import (
 	"github.com/tensorchord/envd/pkg/version"
 )
 
-type versionJson struct {
+type versionJSON struct {
 	Envd              string `json:"envd"`
 	BuildDate         string `json:"build_date,omitempty"`
 	GitCommit         string `json:"git_commit,omitempty"`
@@ -45,11 +45,11 @@ func PrintVersion(clicontext *cli.Context) error {
 	detail := clicontext.Bool("detail")
 	ver := version.GetVersion()
 	detailVer, err := formatter.GetDetailedVersion(clicontext)
-	output := versionJson{
+	output := versionJSON{
 		Envd: version.GetVersion().String(),
 	}
 	if short {
-		return printJson(output)
+		return printJSON(output)
 	}
 	output.BuildDate = ver.BuildDate
 	output.GitCommit = ver.GitCommit
@@ -74,5 +74,5 @@ func PrintVersion(clicontext *cli.Context) error {
 			output.DefaultRuntime = detailVer.DefaultRuntime
 		}
 	}
-	return printJson(output)
+	return printJSON(output)
 }

--- a/pkg/app/formatter/table/context.go
+++ b/pkg/app/formatter/table/context.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/types"
+)
+
+func RenderContext(w io.Writer, contexts types.EnvdContext) {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{"context", "builder", "builder addr", "runner", "runner addr"})
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, p := range contexts.Contexts {
+		envRow := make([]string, 5)
+		if p.Name == contexts.Current {
+			envRow[0] = fmt.Sprintf("%s (current)", p.Name)
+		} else {
+			envRow[0] = p.Name
+		}
+		envRow[1] = string(p.Builder)
+		envRow[2] = fmt.Sprintf("%s://%s", p.Builder, p.BuilderAddress)
+		envRow[3] = string(p.Runner)
+		if p.RunnerAddress != nil {
+			envRow[4] = formatter.StringOrNone(*p.RunnerAddress)
+		}
+		table.Append(envRow)
+	}
+	table.Render()
+}

--- a/pkg/app/formatter/table/context.go
+++ b/pkg/app/formatter/table/context.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/olekukonko/tablewriter"
+
 	"github.com/tensorchord/envd/pkg/app/formatter"
 	"github.com/tensorchord/envd/pkg/types"
 )

--- a/pkg/app/formatter/table/env.go
+++ b/pkg/app/formatter/table/env.go
@@ -1,0 +1,115 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/types"
+)
+
+func RenderEnvironments(w io.Writer, envs []types.EnvdEnvironment) {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{
+		"Name", "Endpoint", "SSH Target", "Image",
+		"GPU", "CUDA", "CUDNN", "Status",
+	})
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, env := range envs {
+		envRow := make([]string, 9)
+		envRow[0] = env.Name
+		envRow[1] = formatter.FormatEndpoint(env)
+		envRow[2] = fmt.Sprintf("%s.envd", env.Name)
+		envRow[3] = env.Spec.Image
+		envRow[4] = strconv.FormatBool(env.GPU)
+		envRow[5] = formatter.StringOrNone(env.CUDA)
+		envRow[6] = formatter.StringOrNone(env.CUDNN)
+		envRow[7] = env.Status.Phase
+		table.Append(envRow)
+	}
+	table.Render()
+}
+
+func RenderPortBindings(w io.Writer, ports []types.PortBinding) {
+	if ports == nil {
+		return
+	}
+	table := createTable(w, []string{"Name", "Container Port", "Protocol", "Host IP", "Host Port"})
+	for _, port := range ports {
+		row := make([]string, 5)
+		row[0] = port.Name
+		row[1] = port.Port
+		row[2] = port.Protocol
+		row[3] = port.HostIP
+		row[4] = port.HostPort
+		table.Append(row)
+	}
+	table.Render()
+}
+
+func RenderDependencies(w io.Writer, dep *types.Dependency) {
+	if dep == nil {
+		return
+	}
+	table := createTable(w, []string{"Dependencies", "Type"})
+	for _, p := range dep.PyPIPackages {
+		envRow := make([]string, 2)
+		envRow[0] = p
+		envRow[1] = "Python"
+		table.Append(envRow)
+	}
+	for _, p := range dep.APTPackages {
+		envRow := make([]string, 2)
+		envRow[0] = p
+		envRow[1] = "APT"
+		table.Append(envRow)
+	}
+	table.Render()
+}
+
+func createTable(w io.Writer, headers []string) *tablewriter.Table {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader(headers)
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(true)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	return table
+}

--- a/pkg/app/formatter/table/env.go
+++ b/pkg/app/formatter/table/env.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"github.com/olekukonko/tablewriter"
+
 	"github.com/tensorchord/envd/pkg/app/formatter"
 	"github.com/tensorchord/envd/pkg/types"
 )

--- a/pkg/app/formatter/table/image.go
+++ b/pkg/app/formatter/table/image.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"io"
+	"strconv"
+
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/go-units"
+	"github.com/olekukonko/tablewriter"
+
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/types"
+)
+
+func RenderImages(w io.Writer, imgs []types.EnvdImage) {
+	table := tablewriter.NewWriter(w)
+	table.SetHeader([]string{"Name", "Context", "GPU", "CUDA", "CUDNN", "Image ID", "Created", "Size"})
+
+	table.SetAutoWrapText(false)
+	table.SetAutoFormatHeaders(true)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCenterSeparator("")
+	table.SetColumnSeparator("")
+	table.SetRowSeparator("")
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetTablePadding("\t") // pad with tabs
+	table.SetNoWhiteSpace(true)
+
+	for _, img := range imgs {
+		envRow := make([]string, 8)
+		envRow[0] = img.Name
+		envRow[1] = formatter.StringOrNone(img.BuildContext)
+		envRow[2] = strconv.FormatBool(img.GPU)
+		envRow[3] = formatter.StringOrNone(img.CUDA)
+		envRow[4] = formatter.StringOrNone(img.CUDNN)
+		envRow[5] = stringid.TruncateID(img.Digest)
+		envRow[6] = formatter.CreatedSinceString(img.Created)
+		envRow[7] = units.HumanSizeWithPrecision(float64(img.Size), 3)
+		table.Append(envRow)
+	}
+	table.Render()
+}

--- a/pkg/app/formatter/table/version.go
+++ b/pkg/app/formatter/table/version.go
@@ -23,7 +23,13 @@ import (
 	"github.com/tensorchord/envd/pkg/version"
 )
 
+const indent = "  "
+
 func PrintVersion(clicontext *cli.Context) error {
+	IdentPrintf := func(format string, a ...any) {
+		fmt.Printf(indent+format, a...)
+	}
+
 	short := clicontext.Bool("short")
 	detail := clicontext.Bool("detail")
 	ver := version.GetVersion()
@@ -32,27 +38,27 @@ func PrintVersion(clicontext *cli.Context) error {
 	if short {
 		return nil
 	}
-	fmt.Printf("  BuildDate: %s\n", ver.BuildDate)
-	fmt.Printf("  GitCommit: %s\n", ver.GitCommit)
-	fmt.Printf("  GitTreeState: %s\n", ver.GitTreeState)
+	IdentPrintf("BuildDate: %s\n", ver.BuildDate)
+	IdentPrintf("GitCommit: %s\n", ver.GitCommit)
+	IdentPrintf("GitTreeState: %s\n", ver.GitTreeState)
 	if ver.GitTag != "" {
-		fmt.Printf("  GitTag: %s\n", ver.GitTag)
+		IdentPrintf("GitTag: %s\n", ver.GitTag)
 	}
-	fmt.Printf("  GoVersion: %s\n", ver.GoVersion)
-	fmt.Printf("  Compiler: %s\n", ver.Compiler)
-	fmt.Printf("  Platform: %s\n", ver.Platform)
+	IdentPrintf("GoVersion: %s\n", ver.GoVersion)
+	IdentPrintf("Compiler: %s\n", ver.Compiler)
+	IdentPrintf("Platform: %s\n", ver.Platform)
 	if detail {
 		if err != nil {
 			fmt.Printf("Error in getting details from Docker Server: %s\n", err)
 		} else {
-			fmt.Printf("  OSType: %s\n", detailVer.OSType)
+			IdentPrintf("OSType: %s\n", detailVer.OSType)
 			if detailVer.OSVersion != "" {
-				fmt.Printf("  OSVersion: %s\n", detailVer.OSVersion)
+				IdentPrintf("OSVersion: %s\n", detailVer.OSVersion)
 			}
-			fmt.Printf("  KernelVersion: %s\n", detailVer.KernelVersion)
-			fmt.Printf("  DockerHostVersion: %s\n", detailVer.DockerVersion)
-			fmt.Printf("  ContainerRuntimes: %s\n", detailVer.ContainerRuntimes)
-			fmt.Printf("  DefaultRuntime: %s\n", detailVer.DefaultRuntime)
+			IdentPrintf("KernelVersion: %s\n", detailVer.KernelVersion)
+			IdentPrintf("DockerHostVersion: %s\n", detailVer.DockerVersion)
+			IdentPrintf("ContainerRuntimes: %s\n", detailVer.ContainerRuntimes)
+			IdentPrintf("DefaultRuntime: %s\n", detailVer.DefaultRuntime)
 		}
 	}
 	return nil

--- a/pkg/app/formatter/table/version.go
+++ b/pkg/app/formatter/table/version.go
@@ -1,0 +1,59 @@
+// Copyright 2022 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/version"
+)
+
+func PrintVersion(clicontext *cli.Context) error {
+	short := clicontext.Bool("short")
+	detail := clicontext.Bool("detail")
+	ver := version.GetVersion()
+	detailVer, err := formatter.GetDetailedVersion(clicontext)
+	fmt.Printf("envd: %s\n", ver)
+	if short {
+		return nil
+	}
+	fmt.Printf("  BuildDate: %s\n", ver.BuildDate)
+	fmt.Printf("  GitCommit: %s\n", ver.GitCommit)
+	fmt.Printf("  GitTreeState: %s\n", ver.GitTreeState)
+	if ver.GitTag != "" {
+		fmt.Printf("  GitTag: %s\n", ver.GitTag)
+	}
+	fmt.Printf("  GoVersion: %s\n", ver.GoVersion)
+	fmt.Printf("  Compiler: %s\n", ver.Compiler)
+	fmt.Printf("  Platform: %s\n", ver.Platform)
+	if detail {
+		if err != nil {
+			fmt.Printf("Error in getting details from Docker Server: %s\n", err)
+		} else {
+			fmt.Printf("  OSType: %s\n", detailVer.OSType)
+			if detailVer.OSVersion != "" {
+				fmt.Printf("  OSVersion: %s\n", detailVer.OSVersion)
+			}
+			fmt.Printf("  KernelVersion: %s\n", detailVer.KernelVersion)
+			fmt.Printf("  DockerHostVersion: %s\n", detailVer.DockerVersion)
+			fmt.Printf("  ContainerRuntimes: %s\n", detailVer.ContainerRuntimes)
+			fmt.Printf("  DefaultRuntime: %s\n", detailVer.DefaultRuntime)
+		}
+	}
+	return nil
+}

--- a/pkg/app/image.go
+++ b/pkg/app/image.go
@@ -26,6 +26,8 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli/v2"
 
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/app/formatter/json"
 	"github.com/tensorchord/envd/pkg/envd"
 	"github.com/tensorchord/envd/pkg/home"
 	"github.com/tensorchord/envd/pkg/types"
@@ -50,22 +52,7 @@ var CommandListImage = &cli.Command{
 	Aliases: []string{"ls", "l"},
 	Usage:   "List envd images",
 	Flags: []cli.Flag{
-		&cli.StringFlag{
-			Name:     "format",
-			Usage:    "Format of output, could be \"json\" or \"table\"",
-			Aliases:  []string{"f"},
-			Value:    "table",
-			Required: false,
-			Action: func(clicontext *cli.Context, v string) error {
-				switch v {
-				case
-					"table",
-					"json":
-					return nil
-				}
-				return errors.Errorf("Argument format only allows \"json\" and \"table\", found %v", v)
-			},
-		},
+		&formatter.FormatFlag,
 	},
 	Action: getImage,
 }
@@ -89,14 +76,14 @@ func getImage(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		renderTableImages(os.Stdout, imgs)
+		renderImages(os.Stdout, imgs)
 	case "json":
-		return renderjsonImages(imgs)
+		return json.PrintImages(imgs)
 	}
 	return nil
 }
 
-func renderTableImages(w io.Writer, imgs []types.EnvdImage) {
+func renderImages(w io.Writer, imgs []types.EnvdImage) {
 	table := tablewriter.NewWriter(w)
 	table.SetHeader([]string{"Name", "Context", "GPU", "CUDA", "CUDNN", "Image ID", "Created", "Size"})
 
@@ -125,35 +112,6 @@ func renderTableImages(w io.Writer, imgs []types.EnvdImage) {
 		table.Append(envRow)
 	}
 	table.Render()
-}
-
-type imgJsonDisplay struct {
-	Name    string `json:"name"`
-	Context string `json:"endpoint,omitempty"`
-	GPU     bool   `json:"gpu"`
-	CUDA    string `json:"cuda,omitempty"`
-	CUDNN   string `json:"cudnn,omitempty"`
-	ImageID string `json:"image_id"`
-	Created string `json:"created"`
-	Size    string `json:"size"`
-}
-
-func renderjsonImages(imgs []types.EnvdImage) error {
-	output := []imgJsonDisplay{}
-	for _, img := range imgs {
-		item := imgJsonDisplay{
-			Name:    img.Name,
-			Context: img.BuildContext,
-			GPU:     img.GPU,
-			CUDA:    img.CUDA,
-			CUDNN:   img.CUDNN,
-			ImageID: stringid.TruncateID(img.Digest),
-			Created: createdSinceString(img.Created),
-			Size:    units.HumanSizeWithPrecision(float64(img.Size), 3),
-		}
-		output = append(output, item)
-	}
-	return PrintJson(output)
 }
 
 func stringOrNone(cuda string) string {

--- a/pkg/app/image_describe.go
+++ b/pkg/app/image_describe.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tensorchord/envd/pkg/envd"
 	"github.com/tensorchord/envd/pkg/home"
+	"github.com/tensorchord/envd/pkg/types"
 )
 
 var CommandDescribeImage = &cli.Command{
@@ -33,6 +34,22 @@ var CommandDescribeImage = &cli.Command{
 			Name:    "image",
 			Usage:   "Specify the image to use",
 			Aliases: []string{"i"},
+		},
+		&cli.StringFlag{
+			Name:     "format",
+			Usage:    "Format of output, could be \"json\" or \"table\"",
+			Aliases:  []string{"f"},
+			Value:    "table",
+			Required: false,
+			Action: func(clicontext *cli.Context, v string) error {
+				switch v {
+				case
+					"table",
+					"json":
+					return nil
+				}
+				return errors.Errorf("Argument format only allows \"json\" and \"table\", found %v", v)
+			},
 		},
 	},
 	Action: getImageDependency,
@@ -58,6 +75,12 @@ func getImageDependency(clicontext *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to list dependencies")
 	}
-	renderDependencies(os.Stdout, dep)
+	format := clicontext.String("format")
+	switch format {
+	case "table":
+		renderTableDependencies(os.Stdout, dep)
+	case "json":
+		return renderjsonEnvDesp(dep, []types.PortBinding{})
+	}
 	return nil
 }

--- a/pkg/app/image_describe.go
+++ b/pkg/app/image_describe.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tensorchord/envd/pkg/app/formatter"
 	"github.com/tensorchord/envd/pkg/app/formatter/json"
+	"github.com/tensorchord/envd/pkg/app/formatter/table"
 	"github.com/tensorchord/envd/pkg/envd"
 	"github.com/tensorchord/envd/pkg/home"
 	"github.com/tensorchord/envd/pkg/types"
@@ -65,7 +66,7 @@ func getImageDependency(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		renderDependencies(os.Stdout, dep)
+		table.RenderDependencies(os.Stdout, dep)
 	case "json":
 		return json.PrintEnvironmentDescriptions(dep, []types.PortBinding{})
 	}

--- a/pkg/app/image_describe.go
+++ b/pkg/app/image_describe.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/urfave/cli/v2"
 
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/app/formatter/json"
 	"github.com/tensorchord/envd/pkg/envd"
 	"github.com/tensorchord/envd/pkg/home"
 	"github.com/tensorchord/envd/pkg/types"
@@ -35,22 +37,7 @@ var CommandDescribeImage = &cli.Command{
 			Usage:   "Specify the image to use",
 			Aliases: []string{"i"},
 		},
-		&cli.StringFlag{
-			Name:     "format",
-			Usage:    "Format of output, could be \"json\" or \"table\"",
-			Aliases:  []string{"f"},
-			Value:    "table",
-			Required: false,
-			Action: func(clicontext *cli.Context, v string) error {
-				switch v {
-				case
-					"table",
-					"json":
-					return nil
-				}
-				return errors.Errorf("Argument format only allows \"json\" and \"table\", found %v", v)
-			},
-		},
+		&formatter.FormatFlag,
 	},
 	Action: getImageDependency,
 }
@@ -78,9 +65,9 @@ func getImageDependency(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		renderTableDependencies(os.Stdout, dep)
+		renderDependencies(os.Stdout, dep)
 	case "json":
-		return renderjsonEnvDesp(dep, []types.PortBinding{})
+		return json.PrintEnvironmentDescriptions(dep, []types.PortBinding{})
 	}
 	return nil
 }

--- a/pkg/app/version.go
+++ b/pkg/app/version.go
@@ -15,17 +15,12 @@
 package app
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/urfave/cli/v2"
 
-	"github.com/tensorchord/envd/pkg/envd"
-	"github.com/tensorchord/envd/pkg/home"
-	"github.com/tensorchord/envd/pkg/types"
+	"github.com/tensorchord/envd/pkg/app/formatter"
+	"github.com/tensorchord/envd/pkg/app/formatter/json"
 	"github.com/tensorchord/envd/pkg/version"
 )
 
@@ -47,42 +42,27 @@ var CommandVersion = &cli.Command{
 			Value:   false,
 			Aliases: []string{"d"},
 		},
-		&cli.StringFlag{
-			Name:     "format",
-			Usage:    "Format of output, could be \"json\" or \"table\"",
-			Aliases:  []string{"f"},
-			Value:    "table",
-			Required: false,
-			Action: func(clicontext *cli.Context, v string) error {
-				switch v {
-				case
-					"table",
-					"json":
-					return nil
-				}
-				return errors.Errorf("Argument format only allows \"json\" and \"table\", found %v", v)
-			},
-		},
+		&formatter.FormatFlag,
 	},
-	Action: printVersion,
+	Action: outputVersion,
 }
 
-func printVersion(clicontext *cli.Context) error {
+func outputVersion(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		return printTableVersion(clicontext)
+		return printVersion(clicontext)
 	case "json":
-		return printJsonVersion(clicontext)
+		return json.PrintVersion(clicontext)
 	}
 	return nil
 }
 
-func printTableVersion(clicontext *cli.Context) error {
+func printVersion(clicontext *cli.Context) error {
 	short := clicontext.Bool("short")
 	detail := clicontext.Bool("detail")
 	ver := version.GetVersion()
-	detailVer, err := getDetailedVersion(clicontext)
+	detailVer, err := formatter.GetDetailedVersion(clicontext)
 	fmt.Printf("envd: %s\n", ver)
 	if short {
 		return nil
@@ -110,124 +90,5 @@ func printTableVersion(clicontext *cli.Context) error {
 			fmt.Printf("  DefaultRuntime: %s\n", detailVer.DefaultRuntime)
 		}
 	}
-	return nil
-}
-
-type versionJson struct {
-	Envd              string `json:"envd"`
-	BuildDate         string `json:"build_date,omitempty"`
-	GitCommit         string `json:"git_commit,omitempty"`
-	GitTreeState      string `json:"git_tree_state,omitempty"`
-	GitTag            string `json:"git_tag,omitempty"`
-	GoVersion         string `json:"go_version,omitempty"`
-	Compiler          string `json:"compiler,omitempty"`
-	Platform          string `json:"platform,omitempty"`
-	OSType            string `json:"os_type,omitempty"`
-	OSVersion         string `json:"os_version,omitempty"`
-	KernelVersion     string `json:"kernel_version,omitempty"`
-	DockerHostVersion string `json:"docker_host_version,omitempty"`
-	ContainerRuntimes string `json:"container_runtimes,omitempty"`
-	DefaultRuntime    string `json:"default_runtime,omitempty"`
-}
-
-func printJsonVersion(clicontext *cli.Context) error {
-	short := clicontext.Bool("short")
-	detail := clicontext.Bool("detail")
-	ver := version.GetVersion()
-	detailVer, err := getDetailedVersion(clicontext)
-	output := versionJson{
-		Envd: version.GetVersion().String(),
-	}
-	if short {
-		return PrintJson(output)
-	}
-	output.BuildDate = ver.BuildDate
-	output.GitCommit = ver.GitCommit
-	output.GitTreeState = ver.GitTreeState
-	if ver.GitTag != "" {
-		output.GitTag = ver.GitTag
-	}
-	output.GoVersion = ver.GoVersion
-	output.Compiler = ver.Compiler
-	output.Platform = ver.Platform
-	if detail {
-		if err != nil {
-			fmt.Printf("Error in getting details from Docker Server: %s\n", err)
-		} else {
-			output.OSType = detailVer.OSType
-			if detailVer.OSVersion != "" {
-				output.OSVersion = detailVer.OSVersion
-			}
-			output.KernelVersion = detailVer.KernelVersion
-			output.DockerHostVersion = detailVer.DockerVersion
-			output.ContainerRuntimes = detailVer.ContainerRuntimes
-			output.DefaultRuntime = detailVer.DefaultRuntime
-		}
-	}
-	return PrintJson(output)
-}
-
-func getDetailedVersion(clicontext *cli.Context) (detailedVersion, error) {
-	context, err := home.GetManager().ContextGetCurrent()
-	if err != nil {
-		return detailedVersion{}, errors.Wrap(err, "failed to get the current context")
-	}
-	opt := envd.Options{
-		Context: context,
-	}
-	engine, err := envd.New(clicontext.Context, opt)
-	if err != nil {
-		return detailedVersion{}, errors.Wrap(
-			err, "failed to create engine for docker server",
-		)
-	}
-
-	info, err := engine.GetInfo(clicontext.Context)
-	if err != nil {
-		return detailedVersion{}, errors.Wrap(
-			err, "failed to get detailed version info from docker server",
-		)
-	}
-
-	return detailedVersion{
-		OSVersion:         info.OSVersion,
-		OSType:            info.OSType,
-		KernelVersion:     info.KernelVersion,
-		DockerVersion:     info.ServerVersion,
-		Architecture:      info.Architecture,
-		DefaultRuntime:    info.DefaultRuntime,
-		ContainerRuntimes: GetRuntimes(info),
-	}, nil
-}
-
-type detailedVersion struct {
-	OSVersion         string
-	OSType            string
-	KernelVersion     string
-	Architecture      string
-	DockerVersion     string
-	ContainerRuntimes string
-	DefaultRuntime    string
-}
-
-func GetRuntimes(info *types.EnvdInfo) string {
-	runtimesMap := info.Runtimes
-	keys := make([]string, 0, len(runtimesMap))
-	for k := range runtimesMap {
-		keys = append(keys, k)
-	}
-	return "[" + strings.Join(keys, ",") + "]"
-}
-
-func PrintJson(v any) error {
-	buffer := &bytes.Buffer{}
-	encoder := json.NewEncoder(buffer)
-	// avoid escaped from <none> into "\u003cnone\u003e"
-	encoder.SetEscapeHTML(false)
-	err := encoder.Encode(v)
-	if err != nil {
-		return errors.Wrap(err, "failed to marshal json")
-	}
-	fmt.Print(buffer.String())
 	return nil
 }

--- a/pkg/app/version.go
+++ b/pkg/app/version.go
@@ -15,13 +15,11 @@
 package app
 
 import (
-	"fmt"
-
 	"github.com/urfave/cli/v2"
 
 	"github.com/tensorchord/envd/pkg/app/formatter"
 	"github.com/tensorchord/envd/pkg/app/formatter/json"
-	"github.com/tensorchord/envd/pkg/version"
+	"github.com/tensorchord/envd/pkg/app/formatter/table"
 )
 
 var CommandVersion = &cli.Command{
@@ -51,44 +49,9 @@ func outputVersion(clicontext *cli.Context) error {
 	format := clicontext.String("format")
 	switch format {
 	case "table":
-		return printVersion(clicontext)
+		return table.PrintVersion(clicontext)
 	case "json":
 		return json.PrintVersion(clicontext)
-	}
-	return nil
-}
-
-func printVersion(clicontext *cli.Context) error {
-	short := clicontext.Bool("short")
-	detail := clicontext.Bool("detail")
-	ver := version.GetVersion()
-	detailVer, err := formatter.GetDetailedVersion(clicontext)
-	fmt.Printf("envd: %s\n", ver)
-	if short {
-		return nil
-	}
-	fmt.Printf("  BuildDate: %s\n", ver.BuildDate)
-	fmt.Printf("  GitCommit: %s\n", ver.GitCommit)
-	fmt.Printf("  GitTreeState: %s\n", ver.GitTreeState)
-	if ver.GitTag != "" {
-		fmt.Printf("  GitTag: %s\n", ver.GitTag)
-	}
-	fmt.Printf("  GoVersion: %s\n", ver.GoVersion)
-	fmt.Printf("  Compiler: %s\n", ver.Compiler)
-	fmt.Printf("  Platform: %s\n", ver.Platform)
-	if detail {
-		if err != nil {
-			fmt.Printf("Error in getting details from Docker Server: %s\n", err)
-		} else {
-			fmt.Printf("  OSType: %s\n", detailVer.OSType)
-			if detailVer.OSVersion != "" {
-				fmt.Printf("  OSVersion: %s\n", detailVer.OSVersion)
-			}
-			fmt.Printf("  KernelVersion: %s\n", detailVer.KernelVersion)
-			fmt.Printf("  DockerHostVersion: %s\n", detailVer.DockerVersion)
-			fmt.Printf("  ContainerRuntimes: %s\n", detailVer.ContainerRuntimes)
-			fmt.Printf("  DefaultRuntime: %s\n", detailVer.DefaultRuntime)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
close #1314 

- verson
- context ls
- image ls
- image describe
- env ls
- env describe

Signed-off-by: cutecutecat <starkind1997@gmail.com>

# Examples

Original:
```shell
$ sudo ./envd context ls              
CONTEXT                 BUILDER                 BUILDER ADDR                            RUNNER  RUNNER ADDR 
default (current)       docker-container        docker-container://envd_buildkitd       docker
```

Help page:
```shell
$ sudo ./envd context ls -h
NAME:
   envd context ls - List envd contexts

USAGE:
   envd context ls [command options] [arguments...]

OPTIONS:
   --format value, -f value  Format of output, could be "json" or "table" (default: "table")
   --help, -h                show help (default: false)
```

Bad input:
```shell
$ sudo ./envd context ls --format apple
error: Argument format only allows "json" and "table", found apple
```

Good input:
```shell
$ sudo ./envd context ls --format json 
[{"context":"default","builder":"docker-container","builder_addr":"docker-container://envd_buildkitd","runner":"docker","current":true}]
```

Version example:
```shell
$ sudo ./envd version --format json -d 
{"envd":"v0.2.5-alpha.7+d275938.dirty","build_date":"2022-12-19T07:53:07Z","git_commit":"d275938e0c12b94489e16b786979d936ac84604d","git_tree_state":"dirty","git_tag":"v0.2.5-alpha.7","go_version":"go1.19.3","compiler":"gc","platform":"linux/amd64","os_type":"linux","os_version":"20.04","kernel_version":"5.15.0-52-generic","docker_host_version":"20.10.12","container_runtimes":"[io.containerd.runc.v2,io.containerd.runtime.v1.linux,runc]","default_runtime":"runc"}
```

Env ls example:
```shell
$ sudo ./envd env ls --format json   
[{"name":"var2","ssh_target":"var2.envd","image":"act:var","gpu":false,"status":"Up 5 days"},{"name":"var","ssh_target":"var.envd","image":"var:dev","gpu":false,"status":"Up 5 days"}]
```

Env describe example:
```shell
$ sudo ./envd env describe -e var --format json
{"ports":[{"name":"ssh","container_port":"2222","protocol":"tcp","host_ip":"127.0.0.1","host_port":"43799"}]}
```

image ls and describe is the same.