### PR TITLE
feat: produce ABI-agnostic wheels for python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: arm64, x86_64
         CIBW_ARCHS_LINUX: auto64
+        CIBW_SKIP: pp*
     - name: Build source distribution
       if: runner.os == 'Linux' # Only release source under linux to avoid conflict
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
     - name: Build source distribution
       if: runner.os == 'Linux' # Only release source under linux to avoid conflict
       run: |
+        python3 -m pip install wheel
         python3 setup.py sdist
         mv dist/*.tar.gz wheelhouse/
     - name: Upload to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -58,13 +58,8 @@ class EnvdBuildExt(build_ext):
 
 class bdist_wheel_abi3(bdist_wheel):
     def get_tag(self):
-        python, abi, plat = super().get_tag()
-
-        if python.startswith("cp"):
-            # on CPython, our wheels are abi3 and compatible back to 3.6
-            return "cp36", "abi3", plat
-
-        return python, abi, plat
+        *_, plat = super().get_tag()
+        return "py2.py3", "none", plat
 
 
 class SdistCommand(sdist):

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class EnvdBuildExt(build_ext):
         build_envd_if_not_found()
 
 
-class bdist_wheel_abi3(bdist_wheel):
+class bdist_wheel_universal(bdist_wheel):
     def get_tag(self):
         *_, plat = super().get_tag()
         return "py2.py3", "none", plat
@@ -122,6 +122,6 @@ setup(
     cmdclass=dict(
         build_ext=EnvdBuildExt,
         sdist=SdistCommand,
-        bdist_wheel=bdist_wheel_abi3,
+        bdist_wheel=bdist_wheel_universal,
     ),
 )

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /home/frost/.pyenv/versions/3.10.8/bin
-include-system-site-packages = false
-version = 3.10.8

--- a/venv/pyvenv.cfg
+++ b/venv/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /home/frost/.pyenv/versions/3.10.8/bin
+include-system-site-packages = false
+version = 3.10.8


### PR DESCRIPTION
Signed-off-by: Frost Ming <mianghong@gmail.com>

* * *

The approach is taken from [cibuildwheel Tips and Tricks](https://cibuildwheel.readthedocs.io/en/stable/faq/#abi3), also quote:

>The CPython Limited API is a subset of the Python C Extension API that's declared to be forward-compatible, meaning you can compile wheels for one version of Python, and they'll be compatible with future versions. Wheels that use the Limited API are known as ABI3 wheels.

This will reduce the number of wheels to upload to PyPI