### PR TITLE
feat: Support installing R environment in DEB822 format using internal standardized structure

### DIFF
--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -81,3 +81,13 @@ type RunBuildCommand struct {
 	Commands  []string
 	MountHost bool
 }
+
+type AptConfig struct {
+	Name       string
+	Enabled    string
+	Types      string
+	URIs       string
+	Suites     string
+	Components string
+	Options    []string
+}

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -90,4 +90,5 @@ type AptConfig struct {
 	Suites     string
 	Components string
 	Signed     string
+	Arch       string
 }

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -89,5 +89,5 @@ type AptConfig struct {
 	URIs       string
 	Suites     string
 	Components string
-	Options    []string
+	Signed     string
 }

--- a/pkg/lang/ir/types.go
+++ b/pkg/lang/ir/types.go
@@ -82,7 +82,7 @@ type RunBuildCommand struct {
 	MountHost bool
 }
 
-type AptConfig struct {
+type APTConfig struct {
 	Name       string
 	Enabled    string
 	Types      string

--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -305,7 +305,8 @@ func (g *generalGraph) CompileLLB(uid, gid int) (llb.State, error) {
 		base = userGroup
 	}
 
-	lang, err := g.compileLanguage(base)
+	aptCustom := g.compileUbuntuAPT_DEV(base)
+	lang, err := g.compileLanguage(aptCustom)
 	if err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile language")
 	}

--- a/pkg/lang/ir/v1/r.go
+++ b/pkg/lang/ir/v1/r.go
@@ -26,7 +26,7 @@ func (g generalGraph) installRLang(root llb.State) (llb.State, error) {
 	installR := "apt-get update && apt-get install -y -t focal-cran40 r-base"
 
 	run := root.Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", installR)),
-		llb.WithCustomNamef("[internal] apt-get install r-base"))
+		llb.WithCustomNamef("[internal] installing r-base packages"))
 	return run.Root(), nil
 }
 

--- a/pkg/lang/ir/v1/r.go
+++ b/pkg/lang/ir/v1/r.go
@@ -18,12 +18,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/moby/buildkit/client/llb"
 )
 
 func (g generalGraph) installRLang(root llb.State) (llb.State, error) {
-	return llb.State{}, errors.New("not implemented")
+	var sb strings.Builder
+	sb.WriteString("apt-get update && apt-get install -y -t " + "focal-cran40" + " r-base")
+	run := root.Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", sb.String())),
+		llb.WithCustomNamef("apt-get install r-base"))
+	return run.Root(), nil
 }
 
 func (g generalGraph) installRPackages(root llb.State) llb.State {

--- a/pkg/lang/ir/v1/r.go
+++ b/pkg/lang/ir/v1/r.go
@@ -26,7 +26,7 @@ func (g generalGraph) installRLang(root llb.State) llb.State {
 	installR := "apt-get update && apt-get install -y -t focal-cran40 r-base"
 
 	run := root.Run(llb.Shlexf("bash -c \"%s\"", installR),
-		llb.WithCustomNamef("[internal] installing r-base packages"))
+		llb.WithCustomNamef("[internal] apt install R environment from CRAN repository"))
 	return run.Root()
 }
 

--- a/pkg/lang/ir/v1/r.go
+++ b/pkg/lang/ir/v1/r.go
@@ -21,13 +21,13 @@ import (
 	"github.com/moby/buildkit/client/llb"
 )
 
-func (g generalGraph) installRLang(root llb.State) (llb.State, error) {
+func (g generalGraph) installRLang(root llb.State) llb.State {
 
 	installR := "apt-get update && apt-get install -y -t focal-cran40 r-base"
 
 	run := root.Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", installR)),
 		llb.WithCustomNamef("[internal] installing r-base packages"))
-	return run.Root(), nil
+	return run.Root()
 }
 
 func (g generalGraph) installRPackages(root llb.State) llb.State {

--- a/pkg/lang/ir/v1/r.go
+++ b/pkg/lang/ir/v1/r.go
@@ -25,7 +25,7 @@ func (g generalGraph) installRLang(root llb.State) llb.State {
 
 	installR := "apt-get update && apt-get install -y -t focal-cran40 r-base"
 
-	run := root.Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", installR)),
+	run := root.Run(llb.Shlexf("bash -c \"%s\"", installR),
 		llb.WithCustomNamef("[internal] installing r-base packages"))
 	return run.Root()
 }

--- a/pkg/lang/ir/v1/r.go
+++ b/pkg/lang/ir/v1/r.go
@@ -23,10 +23,11 @@ import (
 
 func (g generalGraph) installRLang(root llb.State) (llb.State, error) {
 	var sb strings.Builder
-	sb.WriteString("apt-get update && apt-get install -y -t " + "focal-cran40" + " r-base")
+	_, err := sb.WriteString("apt-get update && apt-get install -y -t " + "focal-cran40" + " r-base")
+
 	run := root.Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", sb.String())),
 		llb.WithCustomNamef("apt-get install r-base"))
-	return run.Root(), nil
+	return run.Root(), err
 }
 
 func (g generalGraph) installRPackages(root llb.State) llb.State {

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -73,7 +73,7 @@ func (g generalGraph) copyAPTSignature(root llb.State, name string, url string) 
 	return aptSign, path
 }
 
-// configRSrc returns the state and the content in DEB822 format for third-party apt-souce
+// configRSrc returns the state and the content in DEB822 format for third-party apt-source
 // The returned string contains all configuration for adding third-party into apt source list
 // A successful run of configRSrc should return the content strictly follow the DEB822 format
 func (g generalGraph) configRSrc(root llb.State, aptConfig ir.APTConfig, sign string) (llb.State, string) {

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -74,7 +74,7 @@ func (g generalGraph) copyAPTSignature(root llb.State, name string, url string) 
 }
 
 // configRSrc returns the state and the content in DEB822 format for third-party apt-souce
-// The returned string contains all configuration for adding thrid-party into apt source list
+// The returned string contains all configuration for adding third-party into apt source list
 // A successful run of configRSrc should return the content strictly follow the DEB822 format
 func (g generalGraph) configRSrc(root llb.State, aptConfig ir.APTConfig, sign string) (llb.State, string) {
 

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -114,7 +114,7 @@ func (g generalGraph) compileRLang(root llb.State) llb.State {
 			llb.WithCustomName("[internal] setting apt-source folder sources.list.d")).
 		File(llb.Mkfile(file, 0644, []byte(content)),
 			llb.WithCustomName("[internal] setting apt-source file")).
-		Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", "echo 'APT::Sources::Use-Deb822 true;' > /etc/apt/apt.conf")),
+		Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", "echo 'APT::Sources::Use-Deb822 true;\n' >> /etc/apt/apt.conf")),
 			llb.WithCustomName("[internal] enabled Deb822 format apt-source file"))
 
 	return aptRLang.Root()

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -221,7 +221,7 @@ func (g *generalGraph) compileLanguage(root llb.State) (llb.State, error) {
 		lang, err = g.installPython(root)
 	case "r":
 		rSrc := g.compileRLang(root)
-		lang, _ = g.installRLang(rSrc)
+		lang = g.installRLang(rSrc)
 	case "julia":
 		lang, err = g.installJulia(root)
 	}

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -114,7 +114,9 @@ func (g generalGraph) compileRLang(root llb.State) llb.State {
 			llb.WithCustomName("[internal] setting apt-source folder sources.list.d")).
 		File(llb.Mkfile(file, 0644, []byte(content)),
 			llb.WithCustomName("[internal] setting apt-source file")).
-		Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", "echo 'APT::Sources::Use-Deb822 true;\n' >> /etc/apt/apt.conf")),
+		File(llb.Mkfile("/etc/apt/apt.conf.d/DEB822.conf", 0644, []byte("")),
+			llb.WithCustomName("[internal] setting apt-conf file to support DEB822 format")).
+		Run(llb.Shlex(fmt.Sprintf("bash -c \"%s\"", "echo 'APT::Sources::Use-Deb822 true;\n' > /etc/apt/apt.conf.d/DEB822.conf")),
 			llb.WithCustomName("[internal] enabled Deb822 format apt-source file"))
 
 	return aptRLang.Root()

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -53,7 +53,7 @@ func (g generalGraph) compileUbuntuAPT(root llb.State) llb.State {
 func (g generalGraph) copyAPTSignature(root llb.State, name string, url string) (llb.State, string) {
 
 	var fileName = fmt.Sprintf("%s.asc", name)
-	var fileFolder = "/etc/apt/keyrings"
+	const fileFolder = "/etc/apt/keyrings"
 
 	// path stores the location of the signature file
 	// The value of path should be /etc/apt/keyrings/*.asc
@@ -61,7 +61,7 @@ func (g generalGraph) copyAPTSignature(root llb.State, name string, url string) 
 
 	base := llb.Image(builderImage)
 	builder := base.
-		Run(llb.Shlex(fmt.Sprintf("sh -c \"curl %s >> %s\"", url, fileName)),
+		Run(llb.Shlexf("sh -c \"curl %s >> %s\"", url, fileName),
 			llb.WithCustomName("[internal] downloading apt-source signature in base image")).Root()
 
 	aptSign := root.
@@ -105,7 +105,7 @@ func (g generalGraph) configRSrc(root llb.State, aptConfig ir.APTConfig, sign st
 func (g generalGraph) compileRLang(root llb.State) llb.State {
 
 	// sign stores the third-party URI for downloading the signature of the corresponding repo
-	var sign = "https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc"
+	const sign = "https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc"
 	var aptConfig = ir.APTConfig{
 		Name:       "R-base",                                       // Name for the *.sources file in /etc/apt/sources.list.d
 		Enabled:    "yes",                                          // Represents the validation of the third-party repo


### PR DESCRIPTION
Related to the issue: https://github.com/tensorchord/envd/issues/1298

Implement internal functions that help to standardize the way for adding apt-sources using [DEB822](https://manpages.debian.org/buster/apt/sources.list.5.en.html) format. Created a structure that helps to configure the apt-sources:
```golang

type AptConfig struct {
	Name       string
	Enabled    string
	Types      string
	URIs       string
	Suites     string
	Components string
	Signed     string
        Arch       String
}
```
The R environment is hardcoded as the following using official mirror:

```golang
var sign = "https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc"
var aptConfig = ir.AptConfig{
	Name:       "R-base",
	Enabled:    "yes",
	Types:      "deb",
	URIs:       "https://cloud.r-project.org/bin/linux/ubuntu",
	Suites:     "focal-cran40/",
	Components: "",
	Signed:     "R-base.asc",
	Arch:       "",
}
```
The source is also added in /etc/apt/sources.list.d/R-base.sources
To test it, use the following build file:

```
# syntax=v1
def build():
    base(dev=True)
    install.r_lang()
    shell("zsh")
```
Then run R --version command in the poped shell, you should see:
![6e536aa50bacbdd058318fac07ae33a](https://user-images.githubusercontent.com/26356127/208839961-29e329a4-da82-44fc-8690-ed0beedef3fa.png)
