### PR TITLE
fix: v1 change default user group to 1000:1000

### DIFF
--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -283,9 +283,7 @@ func (g *generalGraph) GetEntrypoint(buildContextDir string) ([]string, error) {
 
 func (g *generalGraph) CompileLLB(uid, gid int) (llb.State, error) {
 	g.uid = uid
-
-	// TODO(gaocegege): Remove the hack for https://github.com/tensorchord/envd/issues/370
-	g.gid = 1001
+	g.gid = gid
 	logrus.WithFields(logrus.Fields{
 		"uid": g.uid,
 		"gid": g.gid,

--- a/pkg/lang/ir/v1/user.go
+++ b/pkg/lang/ir/v1/user.go
@@ -42,17 +42,6 @@ func (g *generalGraph) compileUserOwn(root llb.State) llb.State {
 
 // compileUserGroup creates user `envd`
 func (g *generalGraph) compileUserGroup(root llb.State) llb.State {
-	if g.Language.Name == "r" {
-		// r-base image already has GID 1000.
-		// It is a trick, we actually use GID 1000
-		if g.gid == 1000 {
-			g.gid = 1001
-		}
-		if g.uid == 1000 {
-			g.uid = 1001
-		}
-	}
-
 	var res llb.ExecState
 	if g.uid == 0 {
 		res = root.


### PR DESCRIPTION
Signed-off-by: Keming <kemingy94@gmail.com>

* fix https://github.com/tensorchord/envd/issues/1345

This legacy code is because the r-base image already has the 1000:1000. Since we don't relay on the r-base image anymore, we no longer need the 1001 trick.
