### PR TITLE
fix: fix nil pointer dereference when exiting shell

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -244,7 +244,7 @@ func (c generalClient) Attach() error {
 	logrus.Debug("waiting for shell to exit")
 	if err = session.Wait(); err != nil {
 		var ee *ssh.ExitError
-		if ok := errors.As(err, *ee); ok {
+		if ok := errors.As(err, &ee); ok {
 			switch ee.ExitStatus() {
 			case 130:
 				return nil


### PR DESCRIPTION
Fix #1363 