### PR TITLE
fix(CLI): Remove image list in destroy

### DIFF
--- a/pkg/envd/docker.go
+++ b/pkg/envd/docker.go
@@ -72,7 +72,7 @@ func (e dockerEngine) ListImage(ctx context.Context) ([]types.EnvdImage, error) 
 	for _, img := range images {
 		envdImg, err := types.NewImageFromSummary(img)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create envd image from the docker image")
+			return nil, errors.Wrapf(err, "failed to create envd image `%s` from the docker image", img.ID)
 		}
 		envdImgs = append(envdImgs, *envdImg)
 	}

--- a/pkg/envd/docker.go
+++ b/pkg/envd/docker.go
@@ -492,6 +492,12 @@ func (e dockerEngine) Destroy(ctx context.Context, name string) (string, error) 
 
 	ctr, err := e.ContainerInspect(ctx, name)
 	if err != nil {
+		errCause := errors.UnwrapAll(err).Error()
+		if strings.Contains(errCause, "No such container") {
+			// If the container is not found, it is already destroyed or the name is wrong.
+			logger.Infof("cannot find container %s, maybe it's already destroyed or the name is wrong", name)
+			return "", nil
+		}
 		return "", errors.Wrap(err, "failed to inspect the container")
 	}
 

--- a/pkg/types/envd.go
+++ b/pkg/types/envd.go
@@ -188,7 +188,7 @@ func NewImageFromSummary(image types.ImageSummary) (*EnvdImage, error) {
 	}
 	m, err := newManifest(image.Labels)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to parse manifest")
 	}
 	img.EnvdManifest = m
 	return &img, nil


### PR DESCRIPTION
Fix #1372 

Ref https://github.com/tensorchord/envd/commit/0a975de0103d84841252b54b549cddaa6d82d8a6#diff-e2ddd9833874ac79a5e345e2cdb9293b6fa55ab86269dc103de3b27c9288bb77R520

In this func a image list is run. Then it will return an error if there is any broken image.
I run envd destroy --name mnist, it returns an error because python-basic is broken.

Signed-off-by: Ce Gao <cegao@tensorchord.ai>