### PR TITLE
docs: v1 r_lang and julia packages

### DIFF
--- a/e2e/v1/docs/testdata/julia/build.envd
+++ b/e2e/v1/docs/testdata/julia/build.envd
@@ -4,5 +4,5 @@
 def build():
     base(dev=True)
     install.julia()
-    install.julia_packages(names=["Example"])
-    install.julia_packages(names=["JSON", "Random"])
+    install.julia_packages(name=["Example"])
+    install.julia_packages(name=["JSON", "Random"])

--- a/envd/api/v1/install.py
+++ b/envd/api/v1/install.py
@@ -97,7 +97,7 @@ def r_packages(name: List[str]):
     """
 
 
-def julia_packages(names: List[str]):
+def julia_packages(name: List[str]):
     """Install Julia packages.
 
     Args:

--- a/envd/api/v1/install.py
+++ b/envd/api/v1/install.py
@@ -92,20 +92,16 @@ def conda_packages(name: List[str] = [], channel: List[str] = [], env_file: str 
 def r_packages(name: List[str]):
     """Install R packages by R package manager.
 
-    Not implemented yet. Please use v0 if you need R.
-
     Args:
         name (List[str]): package name list
     """
 
 
-def julia_packages(name: List[str]):
+def julia_packages(names: List[str]):
     """Install Julia packages.
 
-    Not implemented yet. Please use v0 if you need Julia.
-
     Args:
-        name (List(str)): List of Julia packages
+        name (List[str]): List of Julia packages
     """
 
 

--- a/pkg/lang/frontend/starlark/v1/install/install.go
+++ b/pkg/lang/frontend/starlark/v1/install/install.go
@@ -143,18 +143,18 @@ func ruleFuncRPackage(thread *starlark.Thread, _ *starlark.Builtin,
 
 func ruleFuncJuliaPackage(thread *starlark.Thread, _ *starlark.Builtin,
 	args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
-	var names *starlark.List
+	var name *starlark.List
 
 	if err := starlark.UnpackArgs(ruleJuliaPackages,
-		args, kwargs, "names", &names); err != nil {
+		args, kwargs, "name", &name); err != nil {
 		return nil, err
 	}
 
-	nameList, err := starlarkutil.ToStringSlice(names)
+	nameList, err := starlarkutil.ToStringSlice(name)
 	if err != nil {
 		return nil, err
 	}
-	logger.Debugf("rule `%s` is invoked, names=%v", ruleJuliaPackages, nameList)
+	logger.Debugf("rule `%s` is invoked, name=%v", ruleJuliaPackages, nameList)
 	err = ir.JuliaPackage(nameList)
 
 	return starlark.None, err


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

One more thing, only `install.julia_packages` use `names` instead of `name`. Shall we align them? cc @VoVAllen @gaocegege 