### PR TITLE
ci: :hammer: only run nightly on main repo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   lint:
     name: lint
+    if: github.repository == 'tensorchord/envd'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
@@ -41,6 +42,7 @@ jobs:
           skip-pkg-cache: true
   test:
     name: test
+    if: github.repository == 'tensorchord/envd'
     env:
       # Disable telemetry.
       ENVD_ANALYTICS: false
@@ -77,6 +79,7 @@ jobs:
           path: coverage.out
   e2e-cli:
     name: e2e-cli
+    if: github.repository == 'tensorchord/envd'
     env:
       # Disable telemetry.
       ENVD_ANALYTICS: false
@@ -113,6 +116,7 @@ jobs:
           path: e2e-cli-coverage.out
   e2e-lang:
     name: e2e-lang
+    if: github.repository == 'tensorchord/envd'
     env:
       # Disable telemetry.
       ENVD_ANALYTICS: false
@@ -149,6 +153,7 @@ jobs:
           path: e2e-lang-coverage.out
   # notifies that all test jobs are finished.
   report:
+    if: github.repository == 'tensorchord/envd'
     needs:
       - test
       - e2e-cli
@@ -188,6 +193,7 @@ jobs:
       #     goveralls -coverprofile=final.out -service=github
   build:
     name: build
+    if: github.repository == 'tensorchord/envd'
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
@@ -212,6 +218,7 @@ jobs:
         run: make
   e2e-doc:
     name: e2e-doc
+    if: github.repository == 'tensorchord/envd'
     env:
       # Disable telemetry.
       ENVD_ANALYTICS: false
@@ -248,6 +255,7 @@ jobs:
           path: e2e-doc-coverage.out
   e2e-cli-v1:
     name: e2e-cli-v1
+    if: github.repository == 'tensorchord/envd'
     env:
       # Disable telemetry.
       ENVD_ANALYTICS: false
@@ -284,6 +292,7 @@ jobs:
           path: e2e-cli-v1-coverage.out
   e2e-lang-v1:
     name: e2e-lang-v1
+    if: github.repository == 'tensorchord/envd'
     env:
       # Disable telemetry.
       ENVD_ANALYTICS: false
@@ -320,6 +329,7 @@ jobs:
           path: e2e-lang-v1-coverage.out
   e2e-doc-v1:
     name: e2e-doc-v1
+    if: github.repository == 'tensorchord/envd'
     env:
       # Disable telemetry.
       ENVD_ANALYTICS: false


### PR DESCRIPTION
Signed-off-by: Wei Zhang <kweizh@gmail.com>

we can now only use conditions under jobs to prevent running on forks, it could be changed if https://github.com/community/community/discussions/16109 make any progress