### PR TITLE
fix: rm remote cache for v1

### DIFF
--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -25,16 +25,13 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/moby/buildkit/client/llb"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	servertypes "github.com/tensorchord/envd-server/api/types"
 
 	"github.com/tensorchord/envd/pkg/config"
-	"github.com/tensorchord/envd/pkg/flag"
 	"github.com/tensorchord/envd/pkg/lang/ir"
 	"github.com/tensorchord/envd/pkg/progress/compileui"
 	"github.com/tensorchord/envd/pkg/types"
 	"github.com/tensorchord/envd/pkg/util/fileutil"
-	"github.com/tensorchord/envd/pkg/version"
 )
 
 func NewGraph() ir.Graph {
@@ -256,20 +253,8 @@ func (g generalGraph) EnvString() []string {
 }
 
 func (g generalGraph) DefaultCacheImporter() (*string, error) {
-	// The base remote cache should work for all languages.
-	var res string
-	if g.CUDA != nil {
-		res = fmt.Sprintf(
-			"type=registry,ref=docker.io/%s/python-cache:envd-%s-cuda-%s-cudnn-%s",
-			viper.GetString(flag.FlagDockerOrganization),
-			version.GetVersionForImageTag(), *g.CUDA, g.CUDNN)
-	} else {
-		res = fmt.Sprintf(
-			"type=registry,ref=docker.io/%s/python-cache:envd-%s",
-			viper.GetString(flag.FlagDockerOrganization),
-			version.GetVersionForImageTag())
-	}
-	return &res, nil
+	// We don't have remote cache for v1
+	return nil, nil
 }
 
 func (g *generalGraph) GetEntrypoint(buildContextDir string) ([]string, error) {


### PR DESCRIPTION
Signed-off-by: Keming <kemingyang@tensorchord.ai>

We don't have the remote cache for v1. It only slows down the 1st build.