### PR TITLE
ci: Remove rowserrcheck linter to avoid warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - ineffassign
     - misspell
     - revive
-    - rowserrcheck
     - sqlclosecheck
     - staticcheck
     - typecheck


### PR DESCRIPTION
This will get rid of the warning when running lint check:
```
 level=warning msg="[linters_context] rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649
```