### PR TITLE
fix: compile vscode extensions with user state

### DIFF
--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -336,14 +336,11 @@ func (g *generalGraph) CompileLLB(uid, gid int) (llb.State, error) {
 		if err != nil {
 			return llb.State{}, errors.Wrap(err, "failed to compile entrypoint")
 		}
-		vscode, err := g.compileVSCode()
+		vscode, err := g.compileVSCode(entrypoint)
 		if err != nil {
 			return llb.State{}, errors.Wrap(err, "failed to compile VSCode extensions")
 		}
-		copy = llb.Merge([]llb.State{
-			entrypoint,
-			vscode,
-		}, llb.WithCustomName("[internal] final dev environment"))
+		copy = vscode
 	}
 
 	// it's necessary to exec `run` with the desired user

--- a/pkg/lang/ir/v1/editor.go
+++ b/pkg/lang/ir/v1/editor.go
@@ -33,7 +33,7 @@ func (g generalGraph) compileVSCode(root llb.State) (llb.State, error) {
 	if len(g.VSCodePlugins) == 0 {
 		return root, nil
 	}
-	inputs := []llb.State{}
+	inputs := []llb.State{root}
 	for _, p := range g.VSCodePlugins {
 		vscodeClient, err := vscode.NewClient(vscode.MarketplaceVendorOpenVSX)
 		if err != nil {
@@ -52,7 +52,7 @@ func (g generalGraph) compileVSCode(root llb.State) (llb.State, error) {
 				CreateDestPath: true,
 			}, llb.WithUIDGID(g.uid, g.gid)),
 			llb.WithCustomNamef("install vscode plugin %s", p.String()))
-		inputs = append(inputs, ext)
+		inputs = append(inputs, llb.Diff(root, ext))
 	}
 	layer := llb.Merge(inputs, llb.WithCustomName("merging plugins for vscode"))
 	return layer, nil

--- a/pkg/lang/ir/v1/editor.go
+++ b/pkg/lang/ir/v1/editor.go
@@ -29,11 +29,11 @@ import (
 	"github.com/tensorchord/envd/pkg/util/fileutil"
 )
 
-func (g generalGraph) compileVSCode() (llb.State, error) {
+func (g generalGraph) compileVSCode(root llb.State) (llb.State, error) {
 	if len(g.VSCodePlugins) == 0 {
 		return llb.Scratch(), nil
 	}
-	inputs := []llb.State{}
+	ext := root
 	for _, p := range g.VSCodePlugins {
 		vscodeClient, err := vscode.NewClient(vscode.MarketplaceVendorOpenVSX)
 		if err != nil {
@@ -45,17 +45,15 @@ func (g generalGraph) compileVSCode() (llb.State, error) {
 			return llb.State{}, err
 		}
 		g.Writer.LogVSCodePlugin(p, compileui.ActionEnd, cached)
-		ext := llb.Scratch().File(llb.Copy(llb.Local(flag.FlagCacheDir),
+		ext = ext.File(llb.Copy(llb.Local(flag.FlagCacheDir),
 			vscodeClient.PluginPath(p),
 			fileutil.EnvdHomeDir(".vscode-server", "extensions", p.String()),
 			&llb.CopyInfo{
 				CreateDestPath: true,
 			}, llb.WithUIDGID(g.uid, g.gid)),
 			llb.WithCustomNamef("install vscode plugin %s", p.String()))
-		inputs = append(inputs, ext)
 	}
-	layer := llb.Merge(inputs, llb.WithCustomName("merging plugins for vscode"))
-	return layer, nil
+	return ext, nil
 }
 
 // nolint:unused


### PR DESCRIPTION
refer to #1563

# description
Currently, the vscode extensions are installed from `llb.Scratch()`, so some softwares could be installed in /root instead of user envd homeDir.

envd up with
```
# syntax=v1

def rust():
    """Install Rust."""
    install.apt_packages(name=["build-essential"])
    run(
        [
            "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
        ]
    )
    runtime.environ(extra_path=["/home/envd/.cargo/bin"])
    
def build():
    base(dev=True)
    rust()
    install.vscode_extensions(["rust-lang.rust-analyzer"])
    runtime.init(["make install"])
```

# Before
In container,
```bash
⬢ [envd]❯ ls ~ -a
.  ..  .bash_logout  .bashrc  .cache  .config  mosec  .profile  .vscode-server

⬢ [envd]❯ sudo ls /root -a
.  ..  .bashrc  .cargo  .profile  .rustup  .zshenv
```
.cargo and .rustup are installed in wrong path `/root`.

# After
```bash
⬢ [envd]❯ ls ~ -a
.   . bash_logout  . cache  . config  . profile  . sudo_as_admin_successful  . zshenv
..  . bashrc       . cargo  mosec    . rustup   . vscode-server

⬢ [envd]❯ sudo ls /root/ -a
.  ..  . bashrc  . profile
```
Now .cargo and .rustup are installed in correct path `~`.