### PR TITLE
feat: download VScode extension by platform

### DIFF
--- a/pkg/editor/vscode/types.go
+++ b/pkg/editor/vscode/types.go
@@ -17,8 +17,8 @@ package vscode
 import "fmt"
 
 const (
-	vendorVSCodeTemplate  = "https://%s.gallery.vsassets.io/_apis/public/gallery/publisher/%s/extension/%s/%s/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage"
-	vendorOpenVSXTemplate = "https://open-vsx.org/api/%s/%s/latest"
+	vendorVSCodeTemplate  = "https://%s.gallery.vsassets.io/_apis/public/gallery/publisher/%s/extension/%s/%s/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage?targetPlatform=%s"
+	vendorOpenVSXTemplate = "https://open-vsx.org/api/%s/%s/latest?targetPlatform=%s"
 )
 
 type MarketplaceVendor string
@@ -31,12 +31,13 @@ const (
 type Plugin struct {
 	Publisher string
 	Extension string
+	Platform  string
 	Version   *string
 }
 
 func (p Plugin) String() string {
 	if p.Version != nil {
-		return fmt.Sprintf("%s.%s-%s", p.Publisher, p.Extension, *p.Version)
+		return fmt.Sprintf("%s.%s-%s@%s", p.Publisher, p.Extension, *p.Version, p.Platform)
 	}
-	return fmt.Sprintf("%s.%s", p.Publisher, p.Extension)
+	return fmt.Sprintf("%s.%s@%s", p.Publisher, p.Extension, p.Platform)
 }

--- a/pkg/editor/vscode/vscode.go
+++ b/pkg/editor/vscode/vscode.go
@@ -60,19 +60,19 @@ func NewClient(vendor MarketplaceVendor) (Client, error) {
 
 func (c generalClient) PluginPath(p Plugin) string {
 	if p.Version != nil {
-		return fmt.Sprintf("%s.%s-%s/extension/", p.Publisher, p.Extension, *p.Version)
+		return fmt.Sprintf("%s.%s-%s@%s/extension/", p.Publisher, p.Extension, *p.Version, p.Platform)
 
 	}
-	return fmt.Sprintf("%s.%s/extension/", p.Publisher, p.Extension)
+	return fmt.Sprintf("%s.%s@%s/extension/", p.Publisher, p.Extension, p.Platform)
 }
 
 func unzipPath(p Plugin) string {
 	if p.Version != nil {
-		return fmt.Sprintf("%s/%s.%s-%s", home.GetManager().CacheDir(),
-			p.Publisher, p.Extension, *p.Version)
+		return fmt.Sprintf("%s/%s.%s-%s@%s", home.GetManager().CacheDir(),
+			p.Publisher, p.Extension, *p.Version, p.Platform)
 	}
-	return fmt.Sprintf("%s/%s.%s", home.GetManager().CacheDir(),
-		p.Publisher, p.Extension)
+	return fmt.Sprintf("%s/%s.%s@%s", home.GetManager().CacheDir(),
+		p.Publisher, p.Extension, p.Platform)
 }
 
 // DownloadOrCache downloads or cache the plugin.
@@ -93,23 +93,24 @@ func (c generalClient) DownloadOrCache(p Plugin) (bool, error) {
 		}
 		// TODO(gaocegege): Support version auto-detection.
 		url = fmt.Sprintf(vendorVSCodeTemplate,
-			p.Publisher, p.Publisher, p.Extension, *p.Version)
-		filename = fmt.Sprintf("%s/%s.%s-%s.vsix", home.GetManager().CacheDir(),
-			p.Publisher, p.Extension, *p.Version)
+			p.Publisher, p.Publisher, p.Extension, *p.Version, p.Platform)
+		filename = fmt.Sprintf("%s/%s.%s-%s@%s.vsix", home.GetManager().CacheDir(),
+			p.Publisher, p.Extension, *p.Version, p.Platform)
 	} else {
 		var err error
 		url, err = GetLatestVersionURL(p)
 		if err != nil {
 			return false, errors.Wrap(err, "failed to get latest version url")
 		}
-		filename = fmt.Sprintf("%s/%s.%s.vsix", home.GetManager().CacheDir(),
-			p.Publisher, p.Extension)
+		filename = fmt.Sprintf("%s/%s.%s@%s.vsix", home.GetManager().CacheDir(),
+			p.Publisher, p.Extension, p.Platform)
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
 		"publisher": p.Publisher,
 		"extension": p.Extension,
 		"version":   p.Version,
+		"platform":  p.Platform,
 		"url":       url,
 		"file":      filename,
 	})

--- a/pkg/lang/ir/v1/editor.go
+++ b/pkg/lang/ir/v1/editor.go
@@ -31,16 +31,12 @@ import (
 )
 
 func (g generalGraph) compileVSCode(root llb.State) (llb.State, error) {
-	if len(g.VSCodePlugins) == 0 {
-		return root, nil
-	}
 	// TODO(n063h): support multiple platforms
 	p := &v1.Platform{Architecture: "amd64", OS: "linux"}
 	platform, err := vscode.ConvertLLBPlatform(p)
 	if err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to convert llb platform")
 	}
-	inputs := []llb.State{root}
 	for _, p := range g.VSCodePlugins {
 		p.Platform = platform
 		vscodeClient, err := vscode.NewClient(vscode.MarketplaceVendorOpenVSX)
@@ -53,17 +49,15 @@ func (g generalGraph) compileVSCode(root llb.State) (llb.State, error) {
 			return llb.State{}, err
 		}
 		g.Writer.LogVSCodePlugin(p, compileui.ActionEnd, cached)
-		ext := root.File(llb.Copy(llb.Local(flag.FlagCacheDir),
+		root = root.File(llb.Copy(llb.Local(flag.FlagCacheDir),
 			vscodeClient.PluginPath(p),
 			fileutil.EnvdHomeDir(".vscode-server", "extensions", p.String()),
 			&llb.CopyInfo{
 				CreateDestPath: true,
 			}, llb.WithUIDGID(g.uid, g.gid)),
 			llb.WithCustomNamef("install vscode plugin %s", p.String()))
-		inputs = append(inputs, llb.Diff(root, ext))
 	}
-	layer := llb.Merge(inputs, llb.WithCustomName("merging plugins for vscode"))
-	return layer, nil
+	return root, nil
 }
 
 // nolint:unused

--- a/pkg/lang/ir/v1/editor.go
+++ b/pkg/lang/ir/v1/editor.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/moby/buildkit/client/llb"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/tensorchord/envd/pkg/config"
 	"github.com/tensorchord/envd/pkg/editor/vscode"
@@ -33,8 +34,15 @@ func (g generalGraph) compileVSCode(root llb.State) (llb.State, error) {
 	if len(g.VSCodePlugins) == 0 {
 		return root, nil
 	}
+	// TODO(n063h): support multiple platforms
+	p := &v1.Platform{Architecture: "amd64", OS: "linux"}
+	platform, err := vscode.ConvertLLBPlatform(p)
+	if err != nil {
+		return llb.State{}, errors.Wrap(err, "failed to convert llb platform")
+	}
 	inputs := []llb.State{root}
 	for _, p := range g.VSCodePlugins {
+		p.Platform = platform
 		vscodeClient, err := vscode.NewClient(vscode.MarketplaceVendorOpenVSX)
 		if err != nil {
 			return llb.State{}, errors.Wrap(err, "failed to create vscode client")


### PR DESCRIPTION
refer to #1565 

# Description

Currently, envd download extension via https://open-vsx.org/api/Publisher/Extension/latest. Let's take "ms-python.python" and "rust-lang.rust-analyzer" as instances.

When visiting https://open-vsx.org/api/rust-lang/rust-analyzer/latest , you can see the response json like,
![image](https://user-images.githubusercontent.com/29254314/233416863-6eabb697-27b9-418c-8111-02f3aafad692.png)
there's several links to download extension in different platforms.

When visiting https://open-vsx.org/api/ms-python/python/latest , you can see the response json like,
![image](https://user-images.githubusercontent.com/29254314/233416443-06eb266f-0efc-4a5d-aae6-9cff4b9a3f9a.png)
there's several links to download extension in a universal platform.

Since envd take json["files"]["download"] link as extension download link `return files["download"].(string), nil`,it works for extensions in universal platform, but for extensions like rust-analyzer, the json["files"]["download"] link is a download link for default platform win32, which is incompatible for linux containers.



# Before 

envd up with ```
# syntax=v1

def rust():
    """Install Rust."""
    install.apt_packages(name=["build-essential"])
    run(
        [
            "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
        ]
    )
    runtime.environ(extra_path=["/home/envd/.cargo/bin"])
    
def build():
    base(dev=True)
    rust()
    install.vscode_extensions(["rust-lang.rust-analyzer"])
    runtime.init(["make install"])
```

Connect to the dev-container and run ls ~/.vscode-server/extensions/rust-lang.rust-analyzer/server/，you can see the rust-analyzer binary filename endwith '.exe'. which means envd installed a win32 extension in a linux container.

# After

Connect to the dev-container, then
```bash
⬢ [envd]❯ ls ~/.vscode-server/extensions/rust-lang.rust-analyzer\@linux-x64/server/
rust-analyzer
```
And rust-analyzer works well. 