### PR TITLE
feat: confirm `envd destroy` when path and name are both empty

### DIFF
--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -94,7 +94,8 @@ func destroy(clicontext *cli.Context) error {
 			return errors.Wrap(err, "failed to create an env name")
 		}
 	} else {
-		// Destroy the environment in the current directory if user confirms
+		// Both path and name are empty
+		// Destroy the environment in the current directory only if user confirms
 		buildContext, err := filepath.Abs(".")
 		if err != nil {
 			return errors.Wrap(err, "failed to get absolute path of the build context")

--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -15,9 +15,13 @@
 package app
 
 import (
+	"bufio"
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/cockroachdb/errors"
+	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
@@ -51,19 +55,36 @@ var CommandDestroy = &cli.Command{
 	Action: destroy,
 }
 
+// Prompts the user to confirm an operation with [Y/n].
+// If the output is not tty, it will return false automatically.
+func confirm(prompt string) bool {
+	isTerminal := isatty.IsTerminal(os.Stdout.Fd())
+	if !isTerminal {
+		return false
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("%s [Y/n] ", prompt)
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return false
+	}
+
+	response = response[:len(response)-1] // Remove newline character
+	return response == "y" || response == "Y" || response == "yes" || response == "Yes"
+}
+
 func destroy(clicontext *cli.Context) error {
 	path := clicontext.Path("path")
 	name := clicontext.String("name")
 	if path != "" && name != "" {
 		return errors.New("Cannot specify --path and --name at the same time.")
 	}
-	if path == "" && name == "" {
-		return errors.New("Must specify --path or --name. If you want to destroy the current environment, please run `envd destroy -p .`")
-	}
+
 	var ctrName string
 	if name != "" {
 		ctrName = name
-	} else {
+	} else if path != "" {
 		buildContext, err := filepath.Abs(path)
 		if err != nil {
 			return errors.Wrap(err, "failed to get absolute path of the build context")
@@ -72,7 +93,21 @@ func destroy(clicontext *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create an env name")
 		}
+	} else {
+		// Destroy the environment in the current directory if user confirms
+		buildContext, err := filepath.Abs(".")
+		if err != nil {
+			return errors.Wrap(err, "failed to get absolute path of the build context")
+		}
+		ctrName, err = buildutil.CreateEnvNameFromDir(buildContext)
+		if err != nil {
+			return errors.Wrap(err, "failed to create an env name")
+		}
+		if !confirm(fmt.Sprintf("Are you sure you want to destroy container %s in the current directory?", ctrName)) {
+			return nil
+		}
 	}
+
 	context, err := home.GetManager().ContextGetCurrent()
 	if err != nil {
 		return errors.Wrap(err, "failed to get the current context")

--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -58,7 +58,7 @@ func destroy(clicontext *cli.Context) error {
 		return errors.New("Cannot specify --path and --name at the same time.")
 	}
 	if path == "" && name == "" {
-		path = "."
+		return errors.New("Must specify --path or --name. If you want to destroy the current environment, please run `envd destroy -p .`")
 	}
 	var ctrName string
 	if name != "" {


### PR DESCRIPTION
## Summary
The previous behavior of `envd destroy` without both `--path` and `--name` flags was to attempt to delete the environment in the current working directory. This could result in accidental deletion of environments, as seen in issue #1336. This pull request prevents this behavior by adding additional user confirmation to `envd destroy` if both flags are not provided.

### Previous Behavior
```
$ envd destroy
INFO[2023-04-22T06:49:10Z] image(sha256:1a891bf790ef45aec292f63a414fcc4338e1b9e911a313570fb592f9e316a50f) is destroyed 
INFO[2023-04-22T06:49:10Z] environment(envd-quick-start) is destroyed  
```

### Current Behavior
```
$ envd destroy
Are you sure you want to destroy container envd in the current directory? [Y/n]
```

Fixes: #1336

<strike>
Additionally, I have raised [another PR](https://github.com/tensorchord/envd-docs/pull/281) in the envd-docs repository to update the `envd destroy` examples in the documentation to reflect this update.
</strike>