### PR TITLE
fix: reduce llb merge in language part if not necessary

### DIFF
--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -71,7 +71,8 @@ func confirm(prompt string) bool {
 	}
 
 	response = response[:len(response)-1] // Remove newline character
-	return response == "y" || response == "Y" || response == "yes" || response == "Yes"
+	// default is "Yes"
+	return response == "y" || response == "Y" || response == "yes" || response == "Yes" || response == ""
 }
 
 func destroy(clicontext *cli.Context) error {
@@ -104,7 +105,7 @@ func destroy(clicontext *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "failed to create an env name")
 		}
-		if !confirm(fmt.Sprintf("Are you sure you want to destroy container %s in the current directory?", ctrName)) {
+		if !confirm(fmt.Sprintf("Are you sure you want to destroy container `%s` in the current directory?", ctrName)) {
 			return nil
 		}
 	}

--- a/pkg/lang/ir/v1/interface.go
+++ b/pkg/lang/ir/v1/interface.go
@@ -246,6 +246,9 @@ func CondaChannel(channel string) error {
 func CondaPackage(deps []string, channel []string, envFile string) error {
 	g := DefaultGraph.(*generalGraph)
 
+	if g.CondaConfig == nil {
+		return errors.New("cannot install conda packages when conda is not installed")
+	}
 	g.CondaConfig.CondaPackages = append(
 		g.CondaConfig.CondaPackages, deps...)
 

--- a/pkg/lang/ir/v1/python.go
+++ b/pkg/lang/ir/v1/python.go
@@ -138,7 +138,7 @@ func (g generalGraph) compilePyPIPackages(root llb.State) llb.State {
 		run.AddMount(cacheDir, cache,
 			llb.AsPersistentCacheDir(g.CacheID(cacheDir), llb.CacheMountShared), llb.SourcePath("/cache/pip"))
 		run.AddMount(g.getWorkingDir(),
-			llb.Local(flag.FlagBuildContext))
+			llb.Local(flag.FlagBuildContext), llb.Readonly)
 		root = run.Root()
 	}
 

--- a/pkg/lang/ir/v1/python.go
+++ b/pkg/lang/ir/v1/python.go
@@ -137,8 +137,7 @@ func (g generalGraph) compilePyPIPackages(root llb.State) llb.State {
 				llb.WithCustomNamef("pip install -r %s", *g.RequirementsFile))
 		run.AddMount(cacheDir, cache,
 			llb.AsPersistentCacheDir(g.CacheID(cacheDir), llb.CacheMountShared), llb.SourcePath("/cache/pip"))
-		run.AddMount(g.getWorkingDir(),
-			llb.Local(flag.FlagBuildContext), llb.Readonly)
+		run.AddMount(g.getWorkingDir(), llb.Local(flag.FlagBuildContext))
 		root = run.Root()
 	}
 


### PR DESCRIPTION
1. `envd destroy` default is "yes"
2. reduce the LLB merge op if not necessary since diff + merge can take a long time