### PR TITLE
Use default python in the base image

### DIFF
--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -256,11 +256,10 @@ func (g *generalGraph) compileLanguage(root llb.State) (llb.State, error) {
 
 func (g *generalGraph) compileLanguagePackages(root llb.State) llb.State {
 	packs := []llb.State{}
-	pack := root
 
 	// Use default python in the base image if install.python() is not specified.
 	index := g.compilePyPIIndex(root)
-	pack = g.compilePyPIPackages(index)
+	pack := g.compilePyPIPackages(index)
 	if g.CondaConfig != nil {
 		channel := g.compileCondaChannel(pack)
 		pack = g.compileCondaPackages(channel)

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -267,13 +267,6 @@ func (g *generalGraph) compileLanguagePackages(root llb.State) llb.State {
 
 	for _, language := range g.Languages {
 		switch language.Name {
-		case "python":
-			index := g.compilePyPIIndex(root)
-			pack = g.compilePyPIPackages(index)
-			if g.CondaConfig != nil {
-				channel := g.compileCondaChannel(pack)
-				pack = g.compileCondaPackages(channel)
-			}
 		case "r":
 			pack = g.installRPackages(root)
 		case "julia":

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -259,13 +259,11 @@ func (g *generalGraph) compileLanguagePackages(root llb.State) llb.State {
 	pack := root
 
 	// Use default python in the base image if install.python() is not specified.
-	if g.PyPIPackages != nil || g.RequirementsFile != nil || g.PythonWheels != nil {
-		index := g.compilePyPIIndex(root)
-		pack = g.compilePyPIPackages(index)
-		if g.CondaConfig != nil {
-			channel := g.compileCondaChannel(pack)
-			pack = g.compileCondaPackages(channel)
-		}
+	index := g.compilePyPIIndex(root)
+	pack = g.compilePyPIPackages(index)
+	if g.CondaConfig != nil {
+		channel := g.compileCondaChannel(pack)
+		pack = g.compileCondaPackages(channel)
 	}
 
 	for _, language := range g.Languages {

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -257,6 +257,17 @@ func (g *generalGraph) compileLanguage(root llb.State) (llb.State, error) {
 func (g *generalGraph) compileLanguagePackages(root llb.State) llb.State {
 	packs := []llb.State{}
 	pack := root
+
+	// Use default python in the base image if install.python() is not specified.
+	if g.PyPIPackages != nil || g.RequirementsFile != nil || g.PythonWheels != nil {
+		index := g.compilePyPIIndex(root)
+		pack = g.compilePyPIPackages(index)
+		if g.CondaConfig != nil {
+			channel := g.compileCondaChannel(pack)
+			pack = g.compileCondaPackages(channel)
+		}
+	}
+
 	for _, language := range g.Languages {
 		switch language.Name {
 		case "python":


### PR DESCRIPTION
- Use default python in the base image
- Allow users to install Python packages even if they didn't specify `install.python`. 