### PR TITLE
fix: merge language packages to system packages

### DIFF
--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -298,15 +298,15 @@ func (g *generalGraph) CompileLLB(uid, gid int) (llb.State, error) {
 		aptMirror = userGroup
 	}
 
+	systemPackages := g.compileSystemPackages(aptMirror)
 	lang, err := g.compileLanguage(aptMirror)
 	if err != nil {
 		return llb.State{}, errors.Wrap(err, "failed to compile language")
 	}
-	systemPackages := g.compileSystemPackages(aptMirror)
 	merge := llb.Merge([]llb.State{
 		base,
-		llb.Diff(base, lang, llb.WithCustomName("[internal] prepare language")),
 		llb.Diff(base, systemPackages, llb.WithCustomName("[internal] install system packages")),
+		llb.Diff(base, lang, llb.WithCustomName("[internal] prepare language")),
 	}, llb.WithCustomName("[internal] language environment and system packages"))
 	packages := g.compileLanguagePackages(merge)
 	if err != nil {


### PR DESCRIPTION
Before this PR, Ubuntu:18.04 (which contains python2.7) will use the default system Python instead of the conda Python because the merge op will override the language packages layer.