### PR TITLE
fix(v1): rm bash absolute path

### DIFF
--- a/pkg/lang/ir/v1/shell.go
+++ b/pkg/lang/ir/v1/shell.go
@@ -56,7 +56,7 @@ deleted = "x"
 )
 
 func (g *generalGraph) compileShell(root llb.State) (_ llb.State, err error) {
-	g.RuntimeEnviron["SHELL"] = "/usr/bin/bash"
+	g.RuntimeEnviron["SHELL"] = "bash"
 	if g.Shell == shellZSH {
 		g.RuntimeEnviron["SHELL"] = "/usr/bin/zsh"
 		root, err = g.compileZSH(root)

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -150,7 +150,7 @@ func (g generalGraph) compileRun(root llb.State) llb.State {
 			sb.WriteString(c + "\n")
 		}
 
-		cmdStr := fmt.Sprintf("/usr/bin/bash -c '%s'", sb.String())
+		cmdStr := fmt.Sprintf("bash -c '%s'", sb.String())
 		logrus.WithField("command", cmdStr).Debug("compile run command")
 		// Mount the build context into the build process.
 		// TODO(gaocegege): Maybe we should make it readonly,


### PR DESCRIPTION
On Ubuntu:18.04:

```sh
⬢ [envd]❯ which bash
/bin/bash
```
We don't need this absolute path.