### PR TITLE
feat: support mirror ca for buildkitd

### DIFF
--- a/pkg/app/prune.go
+++ b/pkg/app/prune.go
@@ -81,13 +81,13 @@ func prune(clicontext *cli.Context) error {
 	var bkClient buildkitd.Client
 	if c.Builder == types.BuilderTypeMoby {
 		bkClient, err = buildkitd.NewMobyClient(clicontext.Context,
-			c.Builder, c.BuilderAddress, "")
+			c.Builder, c.BuilderAddress, "", false)
 		if err != nil {
 			return errors.Wrap(err, "failed to create moby buildkit client")
 		}
 	} else {
 		bkClient, err = buildkitd.NewClient(clicontext.Context,
-			c.Builder, c.BuilderAddress, "")
+			c.Builder, c.BuilderAddress, "", false)
 		if err != nil {
 			return errors.Wrap(err, "failed to create buildkit client")
 		}

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -88,13 +88,13 @@ func New(ctx context.Context, opt Options) (Builder, error) {
 	var cli buildkitd.Client
 	if c.Builder == types.BuilderTypeMoby {
 		cli, err = buildkitd.NewMobyClient(ctx,
-			c.Builder, c.BuilderAddress, "")
+			c.Builder, c.BuilderAddress, "", false)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create moby buildkit client")
 		}
 	} else {
 		cli, err = buildkitd.NewClient(ctx,
-			c.Builder, c.BuilderAddress, "")
+			c.Builder, c.BuilderAddress, "", false)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create buildkit client")
 		}

--- a/pkg/driver/client.go
+++ b/pkg/driver/client.go
@@ -25,7 +25,7 @@ import (
 type Client interface {
 	// Load loads the image from the reader to the docker host.
 	Load(ctx context.Context, r io.ReadCloser, quiet bool) error
-	StartBuildkitd(ctx context.Context, tag, name, mirror string, timeout time.Duration) (string, error)
+	StartBuildkitd(ctx context.Context, tag, name, mirror string, enableRegistryCA bool, timeout time.Duration) (string, error)
 
 	Exec(ctx context.Context, cname string, cmd []string) error
 

--- a/pkg/driver/nerdctl/nerdctl.go
+++ b/pkg/driver/nerdctl/nerdctl.go
@@ -63,8 +63,8 @@ func (nc *nerdctlClient) Load(ctx context.Context, r io.ReadCloser, quiet bool) 
 	return nil
 }
 
-func (nc *nerdctlClient) StartBuildkitd(ctx context.Context,
-	tag, name, mirror string, timeout time.Duration) (string, error) {
+func (nc *nerdctlClient) StartBuildkitd(ctx context.Context, tag, name, mirror string,
+	enableRegistryCA bool, timeout time.Duration) (string, error) {
 	logger := logrus.WithFields(logrus.Fields{
 		"tag":       tag,
 		"container": name,
@@ -82,6 +82,7 @@ func (nc *nerdctlClient) StartBuildkitd(ctx context.Context,
 	existed, _ := nc.containerExists(ctx, name)
 	if !existed {
 		buildkitdCmd := "buildkitd"
+		// TODO: support mirror CA keypair
 		if mirror != "" {
 			cfg := fmt.Sprintf(`
 [registry."docker.io"]


### PR DESCRIPTION
- fix #https://github.com/tensorchord/envd/issues/1592

Usage:
```sh
envd bootstrap --ca ca=/home/self_ca/contoso.crt,key=/home/self_ca/modelz.key,cert=/home/self_ca/modelz.crt --m https://private-docker-registry.io
```
