### PR TITLE
Documentation improvements (typos, grammar etc)

### DIFF
--- a/envd/api/v0/__init__.py
+++ b/envd/api/v0/__init__.py
@@ -29,7 +29,7 @@ def base(os: str, language: str, image: Optional[str]):
 
     Args:
         os (str): The operating system (i.e. `ubuntu20.04`)
-        language (str): The programing language dependency (i.e. `python3.8`)
+        language (str): The programming language dependency (i.e. `python3.8`)
         image (Optional[str]): Custom image (i.e. `python:3.9-slim`)
     """
 
@@ -80,7 +80,7 @@ def include(git: str):
     """Import from another git repo
 
     This will pull the git repo and execute all the `envd` files. The return value will be a module
-    contains all the variables/functions defined (expect those has `_` prefix).
+    contains all the variables/functions defined (except the ones with `_` prefix).
 
     Args:
         git (str): git URL

--- a/envd/api/v0/install.py
+++ b/envd/api/v0/install.py
@@ -25,7 +25,7 @@ from typing import List, Optional
 
 
 def apt_packages(name: List[str]):
-    """Install package by system-level package manager (apt on Ubuntu)
+    """Install package using the system package manager (apt on Ubuntu)
 
     Args:
         name (List[str]): apt package name list

--- a/envd/api/v0/runtime.py
+++ b/envd/api/v0/runtime.py
@@ -64,7 +64,7 @@ def daemon(commands: List[List[str]]):
     """Run daemon processes in the container
     Proposal: https://github.com/tensorchord/envd/pull/769
 
-    It's better to redirect the logs to local files for debug purposes.
+    It's better to redirect the logs to local files for debugging purposes.
 
     You can find the generated horust config files under `/etc/horust/services`
     and log files under `/var/log/horust` in the container.

--- a/envd/api/v1/__init__.py
+++ b/envd/api/v1/__init__.py
@@ -37,7 +37,7 @@ def base(image: str = "ubuntu:20.04", dev: bool = False):
     """Set up the base env.
 
     Args:
-        image (str): docker image, can be any Debian-based images
+        image (str): docker image, can be any Debian-based image
         dev (bool): enabling the dev env will add lots of development related libraries like
             envd-sshd, vim, git, shell prompt, vscode extensions, etc.
     """
@@ -89,7 +89,7 @@ def include(git: str):
     """Import from another git repo
 
     This will pull the git repo and execute all the `envd` files. The return value will be a module
-    contains all the variables/functions defined (expect those has `_` prefix).
+    contains all the variables/functions defined (except the ones with `_` prefix).
 
     Args:
         git (str): git URL

--- a/envd/api/v1/install.py
+++ b/envd/api/v1/install.py
@@ -58,7 +58,7 @@ def julia():
 
 
 def apt_packages(name: List[str] = []):
-    """Install package by system-level package manager (apt on Ubuntu).
+    """Install package using the system package manager (apt on Ubuntu).
 
     Args:
         name (List[str]): apt package name list

--- a/envd/api/v1/runtime.py
+++ b/envd/api/v1/runtime.py
@@ -70,7 +70,7 @@ def daemon(commands: List[List[str]]):
     """Run daemon processes in the container
     Proposal: https://github.com/tensorchord/envd/pull/769
 
-    It's better to redirect the logs to local files for debug purposes.
+    It's better to redirect the logs to local files for debugging purposes.
 
     You can find the generated horust config files under `/etc/horust/services`
     and log files under `/var/log/horust` in the container.


### PR DESCRIPTION
It seems that `https://github.com/crate-ci/typos` isn't catching some typos in the repo, such as this one: `programing`.
