### PR TITLE
feat: support bootstrap buildkit with HTTP

### DIFF
--- a/pkg/app/prune.go
+++ b/pkg/app/prune.go
@@ -81,13 +81,13 @@ func prune(clicontext *cli.Context) error {
 	var bkClient buildkitd.Client
 	if c.Builder == types.BuilderTypeMoby {
 		bkClient, err = buildkitd.NewMobyClient(clicontext.Context,
-			c.Builder, c.BuilderAddress, "", false)
+			c.Builder, c.BuilderAddress, "", false, false)
 		if err != nil {
 			return errors.Wrap(err, "failed to create moby buildkit client")
 		}
 	} else {
 		bkClient, err = buildkitd.NewClient(clicontext.Context,
-			c.Builder, c.BuilderAddress, "", false)
+			c.Builder, c.BuilderAddress, "", false, false)
 		if err != nil {
 			return errors.Wrap(err, "failed to create buildkit client")
 		}

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -90,13 +90,13 @@ func New(ctx context.Context, opt Options) (Builder, error) {
 	var cli buildkitd.Client
 	if c.Builder == types.BuilderTypeMoby {
 		cli, err = buildkitd.NewMobyClient(ctx,
-			c.Builder, c.BuilderAddress, "", false)
+			c.Builder, c.BuilderAddress, "", false, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create moby buildkit client")
 		}
 	} else {
 		cli, err = buildkitd.NewClient(ctx,
-			c.Builder, c.BuilderAddress, "", false)
+			c.Builder, c.BuilderAddress, "", false, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create buildkit client")
 		}

--- a/pkg/buildkitd/buildkitd.go
+++ b/pkg/buildkitd/buildkitd.go
@@ -66,6 +66,7 @@ type generalClient struct {
 	image            string
 	mirror           string
 	enableRegistryCA bool
+	useHTTP          bool
 
 	driver types.BuilderType
 	socket string
@@ -75,13 +76,14 @@ type generalClient struct {
 }
 
 func NewMobyClient(ctx context.Context, driver types.BuilderType,
-	socket, mirror string, enableRegistryCA bool) (Client, error) {
+	socket, mirror string, enableRegistryCA bool, useHTTP bool) (Client, error) {
 	logrus.Debug("getting moby buildkit client")
 	c := &generalClient{
 		containerName:    socket,
 		image:            viper.GetString(flag.FlagBuildkitdImage),
 		mirror:           mirror,
 		enableRegistryCA: enableRegistryCA,
+		useHTTP:          useHTTP,
 		socket:           socket,
 		driver:           driver,
 	}
@@ -104,19 +106,20 @@ func NewMobyClient(ctx context.Context, driver types.BuilderType,
 		}),
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create buildkit clientt")
+		return nil, errors.Wrap(err, "failed to create buildkit client")
 	}
 	c.Client = bkcli
 	return c, nil
 }
 
 func NewClient(ctx context.Context, driver types.BuilderType,
-	socket, mirror string, enableRegistryCA bool) (Client, error) {
+	socket, mirror string, enableRegistryCA bool, useHTTP bool) (Client, error) {
 	c := &generalClient{
 		containerName:    socket,
 		image:            viper.GetString(flag.FlagBuildkitdImage),
 		mirror:           mirror,
 		enableRegistryCA: enableRegistryCA,
+		useHTTP:          useHTTP,
 		socket:           socket,
 		driver:           driver,
 	}
@@ -174,7 +177,7 @@ func (c *generalClient) maybeStart(ctx context.Context,
 
 	if client != nil {
 		if _, err := client.StartBuildkitd(ctx, c.image, c.containerName, c.mirror,
-			c.enableRegistryCA, runningTimeout); err != nil {
+			c.enableRegistryCA, c.useHTTP, runningTimeout); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/driver/client.go
+++ b/pkg/driver/client.go
@@ -25,7 +25,7 @@ import (
 type Client interface {
 	// Load loads the image from the reader to the docker host.
 	Load(ctx context.Context, r io.ReadCloser, quiet bool) error
-	StartBuildkitd(ctx context.Context, tag, name, mirror string, enableRegistryCA bool, timeout time.Duration) (string, error)
+	StartBuildkitd(ctx context.Context, tag, name, mirror string, enableRegistryCA, useHTTP bool, timeout time.Duration) (string, error)
 
 	Exec(ctx context.Context, cname string, cmd []string) error
 

--- a/pkg/driver/nerdctl/nerdctl.go
+++ b/pkg/driver/nerdctl/nerdctl.go
@@ -64,7 +64,7 @@ func (nc *nerdctlClient) Load(ctx context.Context, r io.ReadCloser, quiet bool) 
 }
 
 func (nc *nerdctlClient) StartBuildkitd(ctx context.Context, tag, name, mirror string,
-	enableRegistryCA bool, timeout time.Duration) (string, error) {
+	enableRegistryCA, useHTTP bool, timeout time.Duration) (string, error) {
 	logger := logrus.WithFields(logrus.Fields{
 		"tag":       tag,
 		"container": name,


### PR DESCRIPTION
Usage:

```sh
envd bootstrap --use-http
```

This will enable communicating with the remote registry with HTTP instead of the default HTTPS.