### PR TITLE
chore: Remove dependabot upgrades from changelog. Fixes #1655

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,79 +20,40 @@
 
 ## v0.3.25 (2023-06-13)
 
- * [b233d20](https://github.com/tensorchord/envd/commit/b233d204bdaed4a2f8544b11c858611d45f6f427) chore(deps): bump crate-ci/typos from 1.14.12 to 1.15.0 (#1643)
- * [170ca4d](https://github.com/tensorchord/envd/commit/170ca4d73d85a4aee0da69625e6d229aaeb2fe87) chore(deps): bump github.com/charmbracelet/bubbletea from 0.24.1 to 0.24.2 (#1645)
- * [7e0ab37](https://github.com/tensorchord/envd/commit/7e0ab3789f1b91d3d60a2b9b495d3e3c2bbce4dd) chore(deps): bump github.com/containers/image/v5 from 5.24.1 to 5.25.0 (#1648)
- * [cb10df9](https://github.com/tensorchord/envd/commit/cb10df940d38a20b7ddd0eaf2311b962aee9ab9a) chore(deps): bump pypa/cibuildwheel from 2.13.0 to 2.13.1 (#1644)
- * [1f9aaf4](https://github.com/tensorchord/envd/commit/1f9aaf4edcd1ec49dc5bfd76dbdd8307f59f1ffc) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.9.5 to 2.10.0 (#1646)
 
 ### Contributors
 
- * dependabot[bot]
 
 ## v0.3.24 (2023-06-08)
 
  * [edf21bf](https://github.com/tensorchord/envd/commit/edf21bfbe8bfd19f6cdb6be505c0dee0dc851570) fix: authentication for private base image (#1639)
- * [1af61d3](https://github.com/tensorchord/envd/commit/1af61d3777c5c19652643411c87c068831899e01) chore(deps): bump github.com/syncthing/syncthing from 1.23.4 to 1.23.5 (#1637)
- * [70b8b60](https://github.com/tensorchord/envd/commit/70b8b60af45704f3de3165462d844ba283a68d3c) chore(deps): bump github.com/containerd/containerd from 1.6.19 to 1.7.2 (#1633)
- * [9cdc234](https://github.com/tensorchord/envd/commit/9cdc234638b72a161bd004338671cf91355acdce) chore(deps): bump github.com/sirupsen/logrus from 1.9.2 to 1.9.3 (#1634)
- * [ef97732](https://github.com/tensorchord/envd/commit/ef97732a6a0258ed104ffb3fc99fcb1036762257) chore(deps): bump github.com/urfave/cli/v2 from 2.25.4 to 2.25.5 (#1635)
- * [b2ae823](https://github.com/tensorchord/envd/commit/b2ae823bf97c4351a9fa26d5317e2ad76211ad2d) chore(deps): bump crate-ci/typos from 1.14.11 to 1.14.12 (#1630)
- * [7d6f107](https://github.com/tensorchord/envd/commit/7d6f107aa2a65572b549169fe92a8f992d592f4c) chore(deps): bump github.com/opencontainers/image-spec from 1.1.0-rc2.0.20221005185240-3a7f492d3f1b to 1.1.0-rc.3 (#1625)
- * [67f0962](https://github.com/tensorchord/envd/commit/67f096235fc580542bda91fa5207374277c4b912) chore(deps): bump github.com/charmbracelet/bubbletea from 0.24.0 to 0.24.1 (#1627)
- * [2f37763](https://github.com/tensorchord/envd/commit/2f37763851fc918707589be335758348eb95dd0b) chore(deps): bump github.com/onsi/gomega from 1.27.6 to 1.27.7 (#1626)
- * [637b1f2](https://github.com/tensorchord/envd/commit/637b1f2447dc21155b5038ea7001658f5db064ed) chore(deps): bump github.com/urfave/cli/v2 from 2.25.3 to 2.25.4 (#1624)
- * [886c1f5](https://github.com/tensorchord/envd/commit/886c1f5c5299251f6fb218df291a676bdade502b) chore(deps): bump pypa/cibuildwheel from 2.12.3 to 2.13.0 (#1621)
- * [c7dc7f9](https://github.com/tensorchord/envd/commit/c7dc7f945e096c54a1b30b23e197fed94ad6eda7) chore(deps): bump dependabot/fetch-metadata from 1.4.0 to 1.5.1 (#1622)
- * [fa5e457](https://github.com/tensorchord/envd/commit/fa5e457a785b95e5453be51fa5bf01c780f21bfd) chore(deps): bump crate-ci/typos from 1.14.10 to 1.14.11 (#1623)
 
 ### Contributors
 
  * Keming
- * dependabot[bot]
 
 ## v0.3.23 (2023-05-25)
 
  * [8a175ed](https://github.com/tensorchord/envd/commit/8a175ed71d59859f57592ddbe73203c4dd8dd6c5) feat: create dest path in io.copy (#1619)
  * [7500fa2](https://github.com/tensorchord/envd/commit/7500fa282a582883501c7a70145b4b36f5d2d40b) Documentation improvements (typos, grammar etc) (#1617)
- * [ef72477](https://github.com/tensorchord/envd/commit/ef724776d2da7e75c092c02d5177d5e2c8d4914c) chore(deps): bump github.com/mattn/go-isatty from 0.0.18 to 0.0.19 (#1613)
- * [8ab6389](https://github.com/tensorchord/envd/commit/8ab63891391e32d9f4c384ff50d6da97fd5e5074) chore(deps): bump github.com/containers/image/v5 from 5.24.1 to 5.25.0 (#1612)
- * [77ff5a5](https://github.com/tensorchord/envd/commit/77ff5a5de9e46fb4a4176e31c3b513d27ab06b08) chore(deps): bump github.com/sirupsen/logrus from 1.9.0 to 1.9.2 (#1614)
- * [e59c289](https://github.com/tensorchord/envd/commit/e59c2897d75316c65e8082c162b0cc4bb37a055c) chore(deps): bump crate-ci/typos from 1.14.9 to 1.14.10 (#1611)
- * [4c34791](https://github.com/tensorchord/envd/commit/4c34791959433ee6a2e691884b83666def08ebff) chore(deps): bump github.com/docker/cli from 24.0.0-rc.2+incompatible to 24.0.1+incompatible (#1616)
- * [0aef7ce](https://github.com/tensorchord/envd/commit/0aef7ceebe7a316c7068ffd89f79a06d184e6efa) chore(deps): bump github.com/stretchr/testify from 1.8.2 to 1.8.3 (#1615)
- * [cef883b](https://github.com/tensorchord/envd/commit/cef883bedc8efe4482bcab9e96ede59b80acd608) chore(deps): bump golang.org/x/sync from 0.1.0 to 0.2.0 (#1608)
- * [889cf6d](https://github.com/tensorchord/envd/commit/889cf6d41e54a7d2b15277e90993d39927516b5a) chore(deps): bump github.com/containerd/containerd from 1.6.19 to 1.7.1 (#1607)
- * [8e3deeb](https://github.com/tensorchord/envd/commit/8e3deebd9b2e2b5655eb3294774435207bf44d73) chore(deps): bump github.com/charmbracelet/bubbletea from 0.23.2 to 0.24.0 (#1610)
- * [bd07f0f](https://github.com/tensorchord/envd/commit/bd07f0fef3e914f2ecdad414651392e7ebb97eb9) chore(deps): bump golang.org/x/crypto from 0.8.0 to 0.9.0 (#1609)
- * [a1615f2](https://github.com/tensorchord/envd/commit/a1615f2083f7c8c79d8bcf9b91578e03bfbfa56b) chore(deps): bump github.com/opencontainers/image-spec from 1.1.0-rc2 to 1.1.0-rc.3 (#1606)
 
 ### Contributors
 
  * Keming
  * Teddy Xinyuan Chen
- * dependabot[bot]
 
 ## v0.3.22 (2023-05-12)
 
  * [6569021](https://github.com/tensorchord/envd/commit/656902196da2e847bdfa30999883702f22a7e118) feat: build image by platform (#1582)
  * [2839aa3](https://github.com/tensorchord/envd/commit/2839aa33bf097b440064aad9a1aaba461647db50) feat: support mirror ca for buildkitd (#1602)
- * [2fbb447](https://github.com/tensorchord/envd/commit/2fbb4475c7da55dc4fc23e25dfb6f6c8666f63cf) chore(deps): bump github.com/docker/distribution from 2.8.1+incompatible to 2.8.2+incompatible (#1604)
  * [fd45847](https://github.com/tensorchord/envd/commit/fd45847e4ebec79bf644d291fa4d2420ea032373) fix: bootstrap with key pair using the same path for pri/pub key (#1603)
  * [2fa41c7](https://github.com/tensorchord/envd/commit/2fa41c7388af41e3ed8de2653d5402ad4bf52369) fix: merge language packages to system packages (#1593)
- * [4306ddf](https://github.com/tensorchord/envd/commit/4306ddf8b490b546f7292df5605a866c63110686) chore(deps): bump github.com/urfave/cli/v2 from 2.25.2 to 2.25.3 (#1600)
- * [e9c1cb9](https://github.com/tensorchord/envd/commit/e9c1cb9efe743a241c8c7436402e866c76d73d53) chore(deps): bump github.com/docker/cli from 24.0.0-beta.2+incompatible to 24.0.0-rc.2+incompatible (#1598)
- * [0700488](https://github.com/tensorchord/envd/commit/0700488320abbaf4a142a93c2f497bf2915d6da7) chore(deps): bump golang.org/x/term from 0.7.0 to 0.8.0 (#1599)
- * [d109a28](https://github.com/tensorchord/envd/commit/d109a280ff9c67f64cf8275dd712ae2c471c6994) chore(deps): bump github.com/moby/term from 0.0.0-20221120202655-abb19827d345 to 0.5.0 (#1601)
- * [e5972b2](https://github.com/tensorchord/envd/commit/e5972b27eb700af06b739f17d0fcbbaa659f0798) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.9.2 to 2.9.4 (#1597)
- * [4f731b9](https://github.com/tensorchord/envd/commit/4f731b9a6ebfa2fb105c34dadd88f053c9e8cbb6) chore(deps): bump crate-ci/typos from 1.14.8 to 1.14.9 (#1596)
  * [d4df02a](https://github.com/tensorchord/envd/commit/d4df02a4e15e73aff64dfd38cc68ffc2058892f3) fix: In debug model, there is progress display. (#1595)
  * [8ab73d8](https://github.com/tensorchord/envd/commit/8ab73d8a7faa9b9fa4a0f882ae904683e2867868) fix(v1): rm bash absolute path (#1594)
 
 ### Contributors
 
  * Keming
- * dependabot[bot]
  * hang lv
  * rrain7
 
@@ -107,29 +68,20 @@
 ## v0.3.20 (2023-05-02)
 
  * [6e055c6](https://github.com/tensorchord/envd/commit/6e055c61fdc1cdba6959c8a54ead5aad6654090e) feat: inherit entrypoint from the base image (#1587)
- * [9673a1f](https://github.com/tensorchord/envd/commit/9673a1fdff7b38cc3f230931e6138eddbc38a5af) chore(deps): bump github.com/urfave/cli/v2 from 2.25.1 to 2.25.2 (#1586)
- * [f638d07](https://github.com/tensorchord/envd/commit/f638d07b6afc4d341b29fc315d60881cab354e9f) chore(deps): bump github.com/opencontainers/image-spec from 1.1.0-rc2.0.20221005185240-3a7f492d3f1b to 1.1.0-rc.3 (#1584)
  * [4a38eca](https://github.com/tensorchord/envd/commit/4a38eca4ddffdb3c24361de90cf2102e7c80fdab) fix: reduce llb merge in language part if not necessary (#1581)
  * [d4e5836](https://github.com/tensorchord/envd/commit/d4e58366802efc444c9e0986d42f3836871abe8a) fix: rm the focus in docs v1 test (#1579)
 
 ### Contributors
 
  * Keming
- * dependabot[bot]
 
 ## v0.3.19 (2023-04-25)
 
  * [ad73e37](https://github.com/tensorchord/envd/commit/ad73e37a17a4142c903d9f7bd4434f67708384fa) fix: hard code amd64 to support remote build (#1577)
- * [599f001](https://github.com/tensorchord/envd/commit/599f00164d821f2b3caac5909d623d504c6d8ca4) chore(deps): bump dependabot/fetch-metadata from 1.3.6 to 1.4.0 (#1573)
- * [78ac026](https://github.com/tensorchord/envd/commit/78ac026949a967504e01f36e2c379de1d7d02acf) chore(deps): bump google.golang.org/protobuf from 1.29.0 to 1.29.1 (#1576)
- * [00cbc47](https://github.com/tensorchord/envd/commit/00cbc47ab31261d2a1ce890974de523979a763fc) chore(deps): bump pypa/cibuildwheel from 2.12.1 to 2.12.3 (#1572)
- * [42c5913](https://github.com/tensorchord/envd/commit/42c591385b96bbaa826f70b3e5a7e8293ec1bac3) chore(deps): bump github.com/syncthing/syncthing from 1.23.1 to 1.23.4 (#1574)
- * [d9bbb37](https://github.com/tensorchord/envd/commit/d9bbb3786f87663e7ff7555a58f156dad4a6bec5) chore(deps): bump crate-ci/typos from 1.14.6 to 1.14.8 (#1571)
 
 ### Contributors
 
  * Ce Gao
- * dependabot[bot]
 
 ## v0.3.18 (2023-04-23)
 
@@ -148,88 +100,52 @@
  * [3e426d2](https://github.com/tensorchord/envd/commit/3e426d25d300fad5b3d903ee35aefbbb26f0564b) Download vs code extension by platform (#1566)
  * [f3acdff](https://github.com/tensorchord/envd/commit/f3acdff65d68e9315a0575e0d41c3354fb2562bc) fix: compile vscode extensions with user state (#1564)
  * [bc0eaf8](https://github.com/tensorchord/envd/commit/bc0eaf86034cd174afa362ecf904c7ea13aec9b6) feat: friendly prompt when exec `envd init` (#1562)
- * [c0010cc](https://github.com/tensorchord/envd/commit/c0010cc59de11a4a188bbfccd31d3e8f4ff65892) chore(deps): bump github.com/docker/cli from 23.0.0-rc.3+incompatible to 24.0.0-beta.2+incompatible (#1561)
- * [60686bc](https://github.com/tensorchord/envd/commit/60686bc63ad4bf95bac36b67fb890fe940dab1c3) chore(deps): bump crate-ci/typos from 1.14.5 to 1.14.6 (#1560)
- * [db8d342](https://github.com/tensorchord/envd/commit/db8d342c1eeb0f41d45b28e6f7b6a82604fb9f4b) chore(deps): bump golang.org/x/crypto from 0.7.0 to 0.8.0 (#1556)
  * [e383395](https://github.com/tensorchord/envd/commit/e3833954ef61b1ca1305303565ff1376f5bd1ea2) feat: bring apt-source compilation earlier (#1554)
- * [dd48167](https://github.com/tensorchord/envd/commit/dd4816746720a813755f59b72e281c2cdc5ce59b) chore(deps): bump golang.org/x/term from 0.6.0 to 0.7.0 (#1555)
- * [c385cb5](https://github.com/tensorchord/envd/commit/c385cb560572c95450a2ba3c3e3f3b9a76f7f9c7) chore(deps): bump crate-ci/typos from 1.14.3 to 1.14.5 (#1557)
- * [b36f07e](https://github.com/tensorchord/envd/commit/b36f07ed014bfed87e9703dae47fdd532cb741e4) chore(deps): bump peter-evans/create-pull-request from 4 to 5 (#1558)
- * [3393bc5](https://github.com/tensorchord/envd/commit/3393bc56290265f79a97e83b6eab45faae1e6ae7) chore(deps): bump github.com/onsi/gomega from 1.27.5 to 1.27.6 (#1552)
 
 ### Contributors
 
- * dependabot[bot]
  * hang lv
  * rrain7
 
 ## v0.3.16 (2023-03-30)
 
  * [04f43da](https://github.com/tensorchord/envd/commit/04f43da45423d18feb3a0899ab3589248be7f701) feat: fall back default builder to buildkit-container (#1548)
- * [1f547f9](https://github.com/tensorchord/envd/commit/1f547f9d7c907557e7f257fa17bf50e39fdce603) chore(deps): bump github.com/onsi/gomega from 1.27.4 to 1.27.5 (#1544)
- * [ba76ca6](https://github.com/tensorchord/envd/commit/ba76ca6823c515a99e4917ecd1b6fb20f1b8006b) chore(deps): bump github.com/urfave/cli/v2 from 2.25.0 to 2.25.1 (#1543)
- * [bf88f7c](https://github.com/tensorchord/envd/commit/bf88f7c9e8d68b539281b24a4070cd4e74c1f8bb) chore(deps): bump github.com/mattn/go-isatty from 0.0.17 to 0.0.18 (#1545)
- * [828fad7](https://github.com/tensorchord/envd/commit/828fad70758f9d81b3811122259ed258d93ff655) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.9.1 to 2.9.2 (#1542)
  * [21c3355](https://github.com/tensorchord/envd/commit/21c3355c682476179255ed976cbdb70e9b47a60d) feat(CLI): add fish completion (#1546)
- * [c3a8e1c](https://github.com/tensorchord/envd/commit/c3a8e1cd827c8a99820bbe34e83b9590e2d071b0) chore(deps): bump crate-ci/typos from 1.13.26 to 1.14.3 (#1540)
 
 ### Contributors
 
  * Kaiyang Chen
- * dependabot[bot]
  * zhang-wei
 
 ## v0.3.15 (2023-03-24)
 
  * [4d62312](https://github.com/tensorchord/envd/commit/4d62312b53db197e6735175eb59e7e58e62dcb60) feat: Support set environment name in `envd up` command (#1495)
  * [9a4cad6](https://github.com/tensorchord/envd/commit/9a4cad69d460a1bee4cf4f6056e670a8f121931c) fix(v1): add base env and runtime env to both dev&nondev (#1538)
- * [176637b](https://github.com/tensorchord/envd/commit/176637b7e68081045937a30101e022bda9a2e74d) chore(deps): bump github.com/schollz/progressbar/v3 from 3.13.0 to 3.13.1 (#1534)
- * [574a93a](https://github.com/tensorchord/envd/commit/574a93adc7a32111fceb37adc27e8fa45632e4e9) chore(deps): bump github.com/onsi/gomega from 1.27.2 to 1.27.4 (#1535)
- * [b644dc5](https://github.com/tensorchord/envd/commit/b644dc5e543e6794c6ecbdb1bb891673514f5b83) chore(deps): bump actions/setup-go from 3 to 4 (#1532)
- * [b4ab3f3](https://github.com/tensorchord/envd/commit/b4ab3f3f4c9f3bda18c99eddeded0cc70319528b) chore(deps): bump crate-ci/typos from 1.13.20 to 1.13.26 (#1533)
  * [c065935](https://github.com/tensorchord/envd/commit/c065935e1ea053a40efd1543f30000f1c5303bc8) feat: support GitHub merge queue (#1531)
 
 ### Contributors
 
  * Keming
  * Nadeshiko Manju
- * dependabot[bot]
 
 ## v0.3.14 (2023-03-17)
 
  * [095811d](https://github.com/tensorchord/envd/commit/095811d63651c121e1e941747569f7f8e264efea) fix: add env to the image itself instead of runtime config (#1528)
  * [84b24ee](https://github.com/tensorchord/envd/commit/84b24eec98a86c479e984d4b8352ec249a791600) fix: upgrade buildkit to fix the secury issue (#1526)
- * [168434a](https://github.com/tensorchord/envd/commit/168434a7585ab0286417bfa023dece9063bc2b39) chore(deps): bump golang.org/x/crypto from 0.6.0 to 0.7.0 (#1515)
- * [2ded823](https://github.com/tensorchord/envd/commit/2ded823e77451959fc37f14a80270fe8715ead14) chore(deps): bump github.com/containerd/containerd from 1.6.18 to 1.7.0 (#1524)
- * [17c7113](https://github.com/tensorchord/envd/commit/17c7113d9b19830ecb4a7c14839c894f05f29326) chore(deps): bump github.com/charmbracelet/lipgloss from 0.6.0 to 0.7.1 (#1525)
- * [8269b6b](https://github.com/tensorchord/envd/commit/8269b6b65e8cabee7fd70b442b079ac8f5c13e66) chore(deps): bump github.com/urfave/cli/v2 from 2.24.4 to 2.25.0 (#1522)
- * [7ef5074](https://github.com/tensorchord/envd/commit/7ef507410df7222c4df5fc6814c08af7994623a9) chore(deps): bump crate-ci/typos from 1.13.16 to 1.13.20 (#1521)
- * [a50d7b5](https://github.com/tensorchord/envd/commit/a50d7b510caa092607bbd08267c03d9012561c34) chore(deps): bump pypa/cibuildwheel from 2.12.0 to 2.12.1 (#1520)
- * [cb90327](https://github.com/tensorchord/envd/commit/cb90327362f768ba37b3d03b1524dd3535156acf) chore(deps): bump github.com/onsi/gomega from 1.27.1 to 1.27.2 (#1513)
- * [60ebd49](https://github.com/tensorchord/envd/commit/60ebd49063caf28a2aa53c7f9b825831ea2cb3a3) chore(deps): bump golang.org/x/term from 0.5.0 to 0.6.0 (#1514)
- * [2a3b592](https://github.com/tensorchord/envd/commit/2a3b59277f53b9901193c7cb6b584fd2850d7ad1) chore(deps): bump crate-ci/typos from 1.13.12 to 1.13.16 (#1512)
  * [8c23bad](https://github.com/tensorchord/envd/commit/8c23bad4f349a4024ee658c11d0ac056856e0692) e2e MNIST deep learning example for R (#1510)
- * [1e1819f](https://github.com/tensorchord/envd/commit/1e1819f0083559cc4998259ae9204089094a0daf) chore(deps): bump github.com/stretchr/testify from 1.8.1 to 1.8.2 (#1507)
- * [c165138](https://github.com/tensorchord/envd/commit/c1651384a0cee0840352c0813b157ff31046dc45) chore(deps): bump github.com/tensorchord/envd-server from 0.0.25 to 0.0.27 (#1505)
- * [484a452](https://github.com/tensorchord/envd/commit/484a45206aa0a03bd9307cb5dd73167d69b069e3) chore(deps): bump crate-ci/typos from 1.13.10 to 1.13.12 (#1504)
  * [b641b0c](https://github.com/tensorchord/envd/commit/b641b0c56b9925ee2024093ec6bd7450fca40b4d) feat: Support installing multi-language environment at the same time (#1501)
  * [f19289e](https://github.com/tensorchord/envd/commit/f19289e1646ed724e1b32b26c527324c95773e80) misc: Use GitHub Issue Form instead of markdown template (#1494)
  * [dc57256](https://github.com/tensorchord/envd/commit/dc57256211e3a7b714ca5185254e66f5a979e02a) feat: add typos to pre-commit and GitHub action (#1493)
- * [6bf7d5b](https://github.com/tensorchord/envd/commit/6bf7d5ba68772759904ba434e0394df2d9d08f5f) chore(deps): bump github.com/urfave/cli/v2 from 2.24.3 to 2.24.4 (#1490)
- * [17e133c](https://github.com/tensorchord/envd/commit/17e133c9680a4e9396dfaf8b3622828d6655a187) chore(deps): bump github.com/onsi/gomega from 1.26.0 to 1.27.1 (#1489)
- * [3919cb2](https://github.com/tensorchord/envd/commit/3919cb21a19c423d77943a98f0a1ee29e0f820b0) chore(deps): bump golang.org/x/net from 0.6.0 to 0.7.0 (#1488)
 
 ### Contributors
 
  * Keming
  * Nadeshiko Manju
  * Zhizhen He
- * dependabot[bot]
  * x0oo0x
 
 ## v0.3.13 (2023-02-20)
 
- * [0f21639](https://github.com/tensorchord/envd/commit/0f21639612f0c438bcd57f07de273858f5a70d81) chore(deps): bump github.com/containerd/containerd from 1.6.17 to 1.6.18 (#1481)
  * [53ba50e](https://github.com/tensorchord/envd/commit/53ba50e06fd1af5026a59c88d3886b5c8ca059de) feat: support CPU and memory limit for docker runner (#1486)
  * [b0143c3](https://github.com/tensorchord/envd/commit/b0143c34b2d868c5f2e2c7b231b5ededca0f29ea) feat: Allow buildkit timeout to be configurable (#1482)
  * [8adb6a9](https://github.com/tensorchord/envd/commit/8adb6a9a0ad7ebea21fd92bdd80883bb71291938) Julia MNIST classification e2e test example (#1484)
@@ -240,56 +156,37 @@
  * Keming
  * Yuan Tang
  * Zhizhen He
- * dependabot[bot]
  * x0oo0x
 
 ## v0.3.12 (2023-02-14)
 
  * [0929661](https://github.com/tensorchord/envd/commit/09296619283ce568866df414bf26db3bda24d9c7) feat: support buildx moby worker in docker 23.0.0 onward to accelerating building process by skipping docker load (#1472)
- * [34ca5b6](https://github.com/tensorchord/envd/commit/34ca5b64ac4ab8c60c40e60dfb8d6269e8cf2a59) chore(deps): bump github.com/charmbracelet/bubbletea from 0.23.1 to 0.23.2 (#1475)
- * [4885a2f](https://github.com/tensorchord/envd/commit/4885a2ff05536f820122e397babc0604212e7681) chore(deps): bump golang.org/x/crypto from 0.5.0 to 0.6.0 (#1476)
- * [5bf3816](https://github.com/tensorchord/envd/commit/5bf381601a3bd276a68ee07b28fecb12dd336fe6) chore(deps): bump github.com/containerd/containerd from 1.6.16 to 1.6.17 (#1474)
  * [986c52a](https://github.com/tensorchord/envd/commit/986c52a2b9ccec53a688de9bd03bd5cc880129bf) fix: unify receiver type for generalManager (#1473)
  * [ae3a1e5](https://github.com/tensorchord/envd/commit/ae3a1e5680bffa214e22f0ef3d8a5b10b6be824a) fix: pass loop variable as a function parameter (#1470)
  * [23e4fa9](https://github.com/tensorchord/envd/commit/23e4fa9a552aecab43566504f6c66ede5f57d6b2) feat: add progress bar for `envd up` and `envd run` (#1460)
- * [d9f8dfc](https://github.com/tensorchord/envd/commit/d9f8dfc8a36d7316dd6908e722418efed7fef17a) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.7.1 to 2.8.0 (#1465)
- * [8706aef](https://github.com/tensorchord/envd/commit/8706aef34c0aa1f3afd17522199548825459495a) chore(deps): bump github.com/urfave/cli/v2 from 2.24.1 to 2.24.3 (#1464)
- * [8413af8](https://github.com/tensorchord/envd/commit/8413af8775cc9d59393abd5a2c1365f23deaa216) chore(deps): bump docker/build-push-action from 3 to 4 (#1463)
- * [4b3e768](https://github.com/tensorchord/envd/commit/4b3e7689fb87b0d0465b89565e7a870669895e6e) chore(deps): bump github.com/cockroachdb/errors from 1.9.0 to 1.9.1 (#1467)
 
 ### Contributors
 
  * Kaiyang Chen
  * Keming
  * Zhizhen He
- * dependabot[bot]
 
 ## v0.3.11 (2023-02-01)
 
  * [89383b5](https://github.com/tensorchord/envd/commit/89383b5bba5229e9cb133515b69a1eccdd0331da) fix: rm redundant ForwardAgent config in ssh config (#1458)
  * [b9f20a4](https://github.com/tensorchord/envd/commit/b9f20a4bfa28bf4bf0cb4ae90c3ba95e5ef23bb1) feat: separate starship installation by using fixed image (#1424)
- * [2ae200b](https://github.com/tensorchord/envd/commit/2ae200bf51339b1ddb0b4474ee5b6d1c9deb459a) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.7.0 to 2.7.1 (#1454)
  * [29ffd89](https://github.com/tensorchord/envd/commit/29ffd895601fad818d5625a03d3e9034d2103ec7) feat: support envd run in local docker context (#1428)
- * [890b712](https://github.com/tensorchord/envd/commit/890b71228b788949cf4266ddeee90027461fadc8) chore(deps): bump github.com/docker/cli from 23.0.0-rc.1+incompatible to 23.0.0-rc.3+incompatible (#1455)
- * [a20aa01](https://github.com/tensorchord/envd/commit/a20aa01d35d5cf93cdc3513adfa321143175687e) chore(deps): bump github.com/onsi/gomega from 1.25.0 to 1.26.0 (#1453)
- * [c781d85](https://github.com/tensorchord/envd/commit/c781d854e659497fbeb4be65fc92baa8fa8195f1) chore(deps): bump github.com/containerd/containerd from 1.6.14 to 1.6.16 (#1451)
- * [08f6975](https://github.com/tensorchord/envd/commit/08f6975f2a62cbfa085b4dda0ad663bbc50eb5db) chore(deps): bump dependabot/fetch-metadata from 1.3.5 to 1.3.6 (#1450)
- * [ba63c8f](https://github.com/tensorchord/envd/commit/ba63c8f29b688ecb6deccf0e5c9fa55875a296ce) chore(deps): bump github.com/spf13/viper from 1.14.0 to 1.15.0 (#1439)
 
 ### Contributors
 
  * Jinjing Zhou
  * Kaiyang Chen
  * Keming
- * dependabot[bot]
 
 ## v0.3.10 (2023-01-25)
 
  * [efdd05f](https://github.com/tensorchord/envd/commit/efdd05f5219c92a5cbae14a57fb55199535b9cd4) fix: rm remote cache for v1 (#1447)
  * [f940354](https://github.com/tensorchord/envd/commit/f9403540e1efe08b8512a728f9cd0eb3232dfb76) feat: add shm size to start options (#1445)
- * [b0320cb](https://github.com/tensorchord/envd/commit/b0320cb2b5f82bc164210c2995caa4ca8dbf50a2) chore(deps): bump github.com/onsi/gomega from 1.24.2 to 1.25.0 (#1442)
- * [0a2d9af](https://github.com/tensorchord/envd/commit/0a2d9af669c2b6d8128fc1b83087f05e88b4d70e) chore(deps): bump golang.org/x/crypto from 0.2.0 to 0.5.0 (#1443)
- * [34c3150](https://github.com/tensorchord/envd/commit/34c3150db5e23dcc25b3270c396c0b1e62a0ab74) chore(deps): bump pypa/cibuildwheel from 2.11.4 to 2.12.0 (#1438)
  * [83c63c7](https://github.com/tensorchord/envd/commit/83c63c7dbce98cd2db53fc317a5366d78ecb5bfd) fix: pip install requirements.txt (#1434)
  * [f47f7a3](https://github.com/tensorchord/envd/commit/f47f7a353cd84dc03f577116bac33090ab8f0eac) doc: add init and daemon debug guide (#1435)
  * [b6d49c6](https://github.com/tensorchord/envd/commit/b6d49c64290e32b4c92be009f40371b296899573) feat: add `make` as a default system package (#1433)
@@ -301,7 +198,6 @@
  * Ce Gao
  * Keming
  * Wei Zhang
- * dependabot[bot]
 
 ## v0.3.9 (2023-01-18)
 
@@ -321,9 +217,7 @@
 
  * [0f556d0](https://github.com/tensorchord/envd/commit/0f556d0b630df70c17b98f5444ba3dcd67abd0bd) fix: change default channel to `defaults` (#1427)
  * [949f188](https://github.com/tensorchord/envd/commit/949f188a074fffef300cc4489806317357931d0b) LLM inference example (#1425)
- * [46f5996](https://github.com/tensorchord/envd/commit/46f59963dfe10c369b21320f754b20721cd085c1) chore(deps): bump github.com/tensorchord/envd-server from 0.0.23 to 0.0.24 (#1388)
  * [b93cd48](https://github.com/tensorchord/envd/commit/b93cd48b1e87642677d1a34120427b7b28192d90) feat: add checksum check for Julia archive file (#1419)
- * [c87846e](https://github.com/tensorchord/envd/commit/c87846e68f2eb0220e0c8698e94894c82fb04491) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.6.1 to 2.7.0 (#1418)
  * [64b5a0a](https://github.com/tensorchord/envd/commit/64b5a0ab5f7799ba3210bf0afa1c5521d078d963) Optimize the logic of adding entry in wsl (#1414)
  * [e1bbd56](https://github.com/tensorchord/envd/commit/e1bbd565b266e785ebb05b0e6227161f12bb8b14) feat: support trust the pypi index in v1, add api doc (#1412)
  * [d1179a6](https://github.com/tensorchord/envd/commit/d1179a6cbaece9d5627fa76dd8a1d464cb253f0e) fix: v1 gid on darwin (#1411)
@@ -334,7 +228,6 @@
 
  * Jinjing Zhou
  * Keming
- * dependabot[bot]
  * li mengyang
  * x0oo0x
 
@@ -347,7 +240,6 @@
  * [b4c08c8](https://github.com/tensorchord/envd/commit/b4c08c835b427a426d20681c4e6093e4ce3c786d) Initial e2e test for R language environment (#1342)
  * [3f7d699](https://github.com/tensorchord/envd/commit/3f7d699c9dfc36cb85433a8796d745774a91f1db) Refactor R package installation (#1381)
  * [aab7f53](https://github.com/tensorchord/envd/commit/aab7f53d2cf57549598c73040d98165fb2ecf5cb) feat: `envd exec` get runtime graph from container labels (#1392)
- * [ede2013](https://github.com/tensorchord/envd/commit/ede201335b95d5071224f9aeeb03d81830472582) chore(deps): bump golang.org/x/term from 0.3.0 to 0.4.0 (#1389)
  * [7034c5d](https://github.com/tensorchord/envd/commit/7034c5dade81293572fdb604d0c323461a13772b) Revert "fix: increase the default buildkit cache limit" (#1386)
  * [f56d95a](https://github.com/tensorchord/envd/commit/f56d95a2eb66bef6044d5653983f714cd0df6da3) fix: increase the default buildkit cache limit (#1382)
  * [3c38b5e](https://github.com/tensorchord/envd/commit/3c38b5e62753d51ec470586b44ada1b14af6eb64) fix: v0 user passwd, add test for root permission (#1379)
@@ -360,7 +252,6 @@
  * Ce Gao
  * Keming
  * Weixiao Huang
- * dependabot[bot]
  * x0oo0x
 
 ## v0.3.5 (2023-01-03)
@@ -388,15 +279,12 @@
 ## v0.3.2 (2023-01-03)
 
  * [095237d](https://github.com/tensorchord/envd/commit/095237dee602eb76dedf9041370173eee367d467) fix: fix nil pointer dereference when exiting shell (#1364)
- * [aae5e27](https://github.com/tensorchord/envd/commit/aae5e27feaa06436fa81c3dc414b28b6b7e21a3b) chore(deps): bump github.com/mattn/go-isatty from 0.0.16 to 0.0.17 (#1361)
  * [b0b5d71](https://github.com/tensorchord/envd/commit/b0b5d71ccb463a7e26e6f3f0cf2ce5d094731367) fix: remove duplicated config and fix Dockerfile pattern (#1362)
  * [bb0fe7c](https://github.com/tensorchord/envd/commit/bb0fe7cac7d6194f2fe095a5aa61bf68a96a564d) Fix: Remove unnecessary user switching code when installing R package (#1351)
  * [4f406ce](https://github.com/tensorchord/envd/commit/4f406ce057c36e1c45ee1e5d2b4c27a8120796ca) fix: fix broken link (#1349)
  * [3093e1a](https://github.com/tensorchord/envd/commit/3093e1a4c64ff1cbff58f656124951d561445a73) fix: v1 change default user group to 1000:1000 (#1347)
  * [571abfe](https://github.com/tensorchord/envd/commit/571abfede9e2166ba5fbefaaf046a4ff926309ad) feat: add --format for commands to output json (#1323)
  * [296680c](https://github.com/tensorchord/envd/commit/296680ce6a02d5a0605936a49de250ba236baaa5) fix: install black[jupyter] for CI check (#1343)
- * [cb33a65](https://github.com/tensorchord/envd/commit/cb33a656801a2f6b6cd04f4b4631ff17b3a2d3a8) chore(deps): bump github.com/tensorchord/envd-server from 0.0.21 to 0.0.23 (#1341)
- * [722fca1](https://github.com/tensorchord/envd/commit/722fca1d11a5519a79f6be29ca48ef67a2414b55) chore(deps): bump pypa/cibuildwheel from 2.11.3 to 2.11.4 (#1340)
  * [7426973](https://github.com/tensorchord/envd/commit/7426973cc33dd56a3967a4c2163575a92359a963) doc: add pytorch2 example (#1339)
  * [e1cb495](https://github.com/tensorchord/envd/commit/e1cb4953d008eb3ed0816e667a59595da9204a3c) fix: doc url in envd github issue page (#1338)
  * [122021d](https://github.com/tensorchord/envd/commit/122021da173e62ddbada683ddba4dfd8eb0432cc) refact: change Shlex(fmt.Sprintf to Shlexf, use ` instead of escape \" (#1337)
@@ -407,7 +295,6 @@
  * Keming
  * Zhizhen He
  * cutecutecat
- * dependabot[bot]
  * x0oo0x
  * xing0821
  * xxchan
@@ -418,17 +305,14 @@
  * [49b3236](https://github.com/tensorchord/envd/commit/49b323609c52d6550b150e5cb44dc941d480d0d0) feat(login): Refactor logic with the new key API (#1333)
  * [1cd917d](https://github.com/tensorchord/envd/commit/1cd917dbe3b1fede67cfe9dd216e86622790b007) fix: upgrade horust to support arm (#1330)
  * [d39adc8](https://github.com/tensorchord/envd/commit/d39adc851a8e967e56221f4ac09775fc09f686af) refactor: combine code with the same logic (#1326)
- * [d1990ec](https://github.com/tensorchord/envd/commit/d1990ec5b8677d9c588919c887c5a304b01b3703) chore(deps): bump github.com/onsi/gomega from 1.24.1 to 1.24.2 (#1320)
  * [c598834](https://github.com/tensorchord/envd/commit/c598834ee34abc8675e19d2fb31bacbcdaa1acdb) fix: conda meta permission for envd user (#1325)
  * [0a48acd](https://github.com/tensorchord/envd/commit/0a48acd355bfe6c62380f7729991993063ca2991) feat: produce ABI-agnostic wheels for python (#1324)
- * [8042997](https://github.com/tensorchord/envd/commit/80429972639cf57d8127a7d5bd8d71ad41834d89) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.6.0 to 2.6.1 (#1321)
 
 ### Contributors
 
  * Ce Gao
  * Frost Ming
  * Keming
- * dependabot[bot]
  * rrain7
  * x0oo0x
 
@@ -455,10 +339,6 @@
  * [935e55d](https://github.com/tensorchord/envd/commit/935e55d5907378ab967d4c767bff7ec3b0c0909a) Interactive cli (#1294)
  * [3800ea2](https://github.com/tensorchord/envd/commit/3800ea2971ea260431fd8fc5ab22ad9b069d8251) fix: add PATH when switch to envd user (#1295)
  * [382a6c1](https://github.com/tensorchord/envd/commit/382a6c150e30ea883c3229b37d851d85ead737bc) feat: install pypi packages in different groups (#1289)
- * [c66f201](https://github.com/tensorchord/envd/commit/c66f201c90a3ffee039a13679c41e792a1ebeac5) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.5.1 to 2.6.0 (#1293)
- * [d15c3ca](https://github.com/tensorchord/envd/commit/d15c3caf450009c4e94172b45474d8e268ac76e8) chore(deps): bump golang.org/x/term from 0.2.0 to 0.3.0 (#1292)
- * [50a8bb6](https://github.com/tensorchord/envd/commit/50a8bb620c178adaa80ce59edea364759afbd5bc) chore(deps): bump github.com/urfave/cli/v2 from 2.23.6 to 2.23.7 (#1291)
- * [99e8a15](https://github.com/tensorchord/envd/commit/99e8a15fd240d83810e2f4414bcb66d3addcb355) chore(deps): bump pypa/cibuildwheel from 2.11.2 to 2.11.3 (#1290)
  * [f7f2b34](https://github.com/tensorchord/envd/commit/f7f2b34a80f616ae4db1c0fdb1c01f6583f4821f) Add config.owner to v1 syntax for setting UID and GID (#1286)
  * [5c4aae9](https://github.com/tensorchord/envd/commit/5c4aae93f797a6ce504f3d09f6395e5492627703) fix: Remove graph access in ssh (#1281)
  * [56d25a0](https://github.com/tensorchord/envd/commit/56d25a01dd37b2c069ae9b4492811c8571a1e714) feat: Support specify resource requirement when creating the environment (#1268)
@@ -467,8 +347,6 @@
  * [8651444](https://github.com/tensorchord/envd/commit/865144482b380cf5d3d6d30dff55a45087aeabc4) Remove incorrect `sudo` command when installing system package (#1273)
  * [235dde9](https://github.com/tensorchord/envd/commit/235dde905643e2eed7ba91e10423b92598d6a12a) fix: Remove ir direct access in ssh (#1271)
  * [06b4880](https://github.com/tensorchord/envd/commit/06b488035a5c21a74c8727fc7d8e85f404a2bb00) feat: Add JWT and user/pwd in envd server context (#1243)
- * [7badc67](https://github.com/tensorchord/envd/commit/7badc67fcf9be813d2124aed7f18acd855847e63) chore(deps): bump github.com/tensorchord/envd-server from 0.0.11 to 0.0.12 (#1266)
- * [cefd1df](https://github.com/tensorchord/envd/commit/cefd1dfa8101a363a762921ec7439f64d1463e2a) chore(deps): bump github.com/urfave/cli/v2 from 2.23.5 to 2.23.6 (#1264)
 
 ### Contributors
 
@@ -477,7 +355,6 @@
  * Frost Ming
  * Jinjing Zhou
  * Keming
- * dependabot[bot]
  * nullday
  * x0oo0x
 
@@ -527,18 +404,14 @@
 
 ## v0.2.5-rc.1 (2022-11-28)
 
- * [a4dad9b](https://github.com/tensorchord/envd/commit/a4dad9b212c41e07175f201e067f891c76277843) chore(deps): bump github.com/tensorchord/envd-server from 0.0.9 to 0.0.10 (#1235)
 
 ### Contributors
 
- * dependabot[bot]
 
 ## v0.2.5-alpha.8 (2022-11-23)
 
  * [2f37901](https://github.com/tensorchord/envd/commit/2f379016002e58c3a87b2a8b2e2afd6ffc6ab9b9) feat: support add new dir to runtime PATH (#1218)
  * [e85f062](https://github.com/tensorchord/envd/commit/e85f0620ad76379e22fdf36f70697b1f8d71444b) feat: merge coverage file and report to goverall (#1211)
- * [7f10440](https://github.com/tensorchord/envd/commit/7f10440a8163f4d23964783fdf83c2e03c66e4f9) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.5.0 to 2.5.1 (#1213)
- * [6db3f15](https://github.com/tensorchord/envd/commit/6db3f152325b674ea67e24fc4ee694f99ea206c3) chore(deps): bump github.com/tensorchord/envd-server from 0.0.8 to 0.0.9 (#1212)
  * [5efb0b1](https://github.com/tensorchord/envd/commit/5efb0b12b98e3000d0ddc6ef015734e65411ac80) fix: only mkdir /home/envd/* when image==nil (#1208)
  * [8c8c3f3](https://github.com/tensorchord/envd/commit/8c8c3f33ada10013b350071a1a36529d993053c4) feat: add name to `envd envs describe` (#1201)
 
@@ -547,7 +420,6 @@
  * Alex Xi
  * Keming
  * cutecutecat
- * dependabot[bot]
 
 ## v0.2.5-alpha.7 (2022-11-15)
 
@@ -583,18 +455,11 @@
 
 ## v0.2.5-alpha.3 (2022-11-14)
 
- * [212f996](https://github.com/tensorchord/envd/commit/212f9966d12f2322fe8c97d14db093448399119e) chore(deps): bump github.com/urfave/cli/v2 from 2.23.4 to 2.23.5 (#1188)
- * [c4854e8](https://github.com/tensorchord/envd/commit/c4854e842a7cee0f2600f5c6eb8d19ca3510369d) chore(deps): bump github.com/onsi/gomega from 1.24.0 to 1.24.1 (#1189)
- * [62b7b2f](https://github.com/tensorchord/envd/commit/62b7b2f204aa5b53688a2b0356d8a746a5fac1e4) chore(deps): bump github.com/moby/buildkit from 0.10.5 to 0.10.6 (#1190)
  * [b1eb44e](https://github.com/tensorchord/envd/commit/b1eb44e4cc80b3422122429d3f29e5d7ffcaf3d6) fix: pre-create the workdir (#1174)
  * [66d9cb0](https://github.com/tensorchord/envd/commit/66d9cb061a033220814813a349fc12495927aef2) fix: Move user to image config (#1173)
  * [dd9dd30](https://github.com/tensorchord/envd/commit/dd9dd3083b363d1d698060255892e6a132b8182a) refact: move env to server (#1172)
  * [2d37b48](https://github.com/tensorchord/envd/commit/2d37b48736c5ba34ea0800c925c31c0c3ff40f13) fix stable diffusion demo via b/c huggingface api change (#1170)
  * [c364958](https://github.com/tensorchord/envd/commit/c364958c1d21d25a7cb782413f6666bd666f7dd1) feat: support envd-server image (#1150)
- * [f9e7c67](https://github.com/tensorchord/envd/commit/f9e7c67a0f16c802fa2aa75a562f77e6f17baef9) chore(deps): bump github.com/spf13/viper from 1.13.0 to 1.14.0 (#1164)
- * [5c9ac69](https://github.com/tensorchord/envd/commit/5c9ac69a584463cf906b27d0ccd200403d7f4974) chore(deps): bump github.com/onsi/gomega from 1.23.0 to 1.24.0 (#1163)
- * [d1de890](https://github.com/tensorchord/envd/commit/d1de8906326ee10a1021dbff80892d8f0c74e637) chore(deps): bump github.com/urfave/cli/v2 from 2.23.0 to 2.23.4 (#1162)
- * [ad5ce11](https://github.com/tensorchord/envd/commit/ad5ce117bdc4433f8894c4b813748d33c6edbd96) chore(deps): bump dependabot/fetch-metadata from 1.3.4 to 1.3.5 (#1161)
  * [6b7a0e9](https://github.com/tensorchord/envd/commit/6b7a0e94937d5e0532139d519e424ccb16bd9de1) fix: cuda tag in image cache (#1156)
  * [1af3449](https://github.com/tensorchord/envd/commit/1af3449ce72e218350c3d4fa19aee64f98ced970) fix: pre mkdir for runtime mount (#1153)
 
@@ -602,7 +467,6 @@
 
  * Ce Gao
  * Keming
- * dependabot[bot]
  * xieydd
 
 ## v0.2.5-alpha.2 (2022-11-03)
@@ -623,35 +487,23 @@
 
  * [235dde9](https://github.com/tensorchord/envd/commit/235dde905643e2eed7ba91e10423b92598d6a12a) fix: Remove ir direct access in ssh (#1271)
  * [06b4880](https://github.com/tensorchord/envd/commit/06b488035a5c21a74c8727fc7d8e85f404a2bb00) feat: Add JWT and user/pwd in envd server context (#1243)
- * [7badc67](https://github.com/tensorchord/envd/commit/7badc67fcf9be813d2124aed7f18acd855847e63) chore(deps): bump github.com/tensorchord/envd-server from 0.0.11 to 0.0.12 (#1266)
- * [cefd1df](https://github.com/tensorchord/envd/commit/cefd1dfa8101a363a762921ec7439f64d1463e2a) chore(deps): bump github.com/urfave/cli/v2 from 2.23.5 to 2.23.6 (#1264)
  * [8594d10](https://github.com/tensorchord/envd/commit/8594d1044874ed2baa3bc74ef9b5e35f3766a6f7) fix: Update python setuptools to python3 (#1261)
  * [0042b24](https://github.com/tensorchord/envd/commit/0042b2481da98c6810e858069f769f3b7ef4808a) feat: add completion command (#1258)
  * [5cbed88](https://github.com/tensorchord/envd/commit/5cbed887e0aa6b0c766f48c0cf8effe85f49d20b) fix: put the binary under bin directly (#1254)
  * [c7fd12b](https://github.com/tensorchord/envd/commit/c7fd12b9047b5c59e555a3d083cdf7cdef1449d6) bug: Update envd-server version to 0.0.11 (#1245)
- * [a4dad9b](https://github.com/tensorchord/envd/commit/a4dad9b212c41e07175f201e067f891c76277843) chore(deps): bump github.com/tensorchord/envd-server from 0.0.9 to 0.0.10 (#1235)
  * [2f37901](https://github.com/tensorchord/envd/commit/2f379016002e58c3a87b2a8b2e2afd6ffc6ab9b9) feat: support add new dir to runtime PATH (#1218)
  * [e85f062](https://github.com/tensorchord/envd/commit/e85f0620ad76379e22fdf36f70697b1f8d71444b) feat: merge coverage file and report to goverall (#1211)
- * [7f10440](https://github.com/tensorchord/envd/commit/7f10440a8163f4d23964783fdf83c2e03c66e4f9) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.5.0 to 2.5.1 (#1213)
- * [6db3f15](https://github.com/tensorchord/envd/commit/6db3f152325b674ea67e24fc4ee694f99ea206c3) chore(deps): bump github.com/tensorchord/envd-server from 0.0.8 to 0.0.9 (#1212)
  * [5efb0b1](https://github.com/tensorchord/envd/commit/5efb0b12b98e3000d0ddc6ef015734e65411ac80) fix: only mkdir /home/envd/* when image==nil (#1208)
  * [8c8c3f3](https://github.com/tensorchord/envd/commit/8c8c3f33ada10013b350071a1a36529d993053c4) feat: add name to `envd envs describe` (#1201)
  * [3fa3070](https://github.com/tensorchord/envd/commit/3fa307098a585b524804bd0beff6697e68440b42) feat: support build owner (#1202)
  * [5462d30](https://github.com/tensorchord/envd/commit/5462d30a556f91741b770e4b4b24c1fd639f5299) fix: release CI add runneradmin to docker group (#1199)
  * [731b6f8](https://github.com/tensorchord/envd/commit/731b6f8271a77096d9a29a03e353e0388f825485) fix: github action release cache command (#1197)
  * [4a7d6cc](https://github.com/tensorchord/envd/commit/4a7d6cca18d9a033c02c1ef235570f64ef987300) fix: daemon command (#1185)
- * [212f996](https://github.com/tensorchord/envd/commit/212f9966d12f2322fe8c97d14db093448399119e) chore(deps): bump github.com/urfave/cli/v2 from 2.23.4 to 2.23.5 (#1188)
- * [c4854e8](https://github.com/tensorchord/envd/commit/c4854e842a7cee0f2600f5c6eb8d19ca3510369d) chore(deps): bump github.com/onsi/gomega from 1.24.0 to 1.24.1 (#1189)
- * [62b7b2f](https://github.com/tensorchord/envd/commit/62b7b2f204aa5b53688a2b0356d8a746a5fac1e4) chore(deps): bump github.com/moby/buildkit from 0.10.5 to 0.10.6 (#1190)
  * [b1eb44e](https://github.com/tensorchord/envd/commit/b1eb44e4cc80b3422122429d3f29e5d7ffcaf3d6) fix: pre-create the workdir (#1174)
  * [66d9cb0](https://github.com/tensorchord/envd/commit/66d9cb061a033220814813a349fc12495927aef2) fix: Move user to image config (#1173)
  * [dd9dd30](https://github.com/tensorchord/envd/commit/dd9dd3083b363d1d698060255892e6a132b8182a) refact: move env to server (#1172)
  * [2d37b48](https://github.com/tensorchord/envd/commit/2d37b48736c5ba34ea0800c925c31c0c3ff40f13) fix stable diffusion demo via b/c huggingface api change (#1170)
  * [c364958](https://github.com/tensorchord/envd/commit/c364958c1d21d25a7cb782413f6666bd666f7dd1) feat: support envd-server image (#1150)
- * [f9e7c67](https://github.com/tensorchord/envd/commit/f9e7c67a0f16c802fa2aa75a562f77e6f17baef9) chore(deps): bump github.com/spf13/viper from 1.13.0 to 1.14.0 (#1164)
- * [5c9ac69](https://github.com/tensorchord/envd/commit/5c9ac69a584463cf906b27d0ccd200403d7f4974) chore(deps): bump github.com/onsi/gomega from 1.23.0 to 1.24.0 (#1163)
- * [d1de890](https://github.com/tensorchord/envd/commit/d1de8906326ee10a1021dbff80892d8f0c74e637) chore(deps): bump github.com/urfave/cli/v2 from 2.23.0 to 2.23.4 (#1162)
- * [ad5ce11](https://github.com/tensorchord/envd/commit/ad5ce117bdc4433f8894c4b813748d33c6edbd96) chore(deps): bump dependabot/fetch-metadata from 1.3.4 to 1.3.5 (#1161)
  * [6b7a0e9](https://github.com/tensorchord/envd/commit/6b7a0e94937d5e0532139d519e424ccb16bd9de1) fix: cuda tag in image cache (#1156)
  * [1af3449](https://github.com/tensorchord/envd/commit/1af3449ce72e218350c3d4fa19aee64f98ced970) fix: pre mkdir for runtime mount (#1153)
  * [46d24fd](https://github.com/tensorchord/envd/commit/46d24fd1331b1b0e223cb2d2223e17d648080bf1) fix: horust cache (#1151)
@@ -666,9 +518,6 @@
  * [0bdca3c](https://github.com/tensorchord/envd/commit/0bdca3c2d54d0eea8ee6b3a14641ae5563971b0e) fix: Remove cwd in conda to enable remote cache (#1125)
  * [535e26a](https://github.com/tensorchord/envd/commit/535e26a0a0d9d3855317d34dcf209e4d8d08efe9) feat(debug): Add llb export (#1124)
  * [d693254](https://github.com/tensorchord/envd/commit/d693254c1a8b19e02aca85934818a4e7b6dde661) fix: Disable telemetry in CI (#1116)
- * [3cba45e](https://github.com/tensorchord/envd/commit/3cba45e36496cd6010d9b07acbb0c7d34826f828) chore(deps): bump github.com/urfave/cli/v2 from 2.20.3 to 2.23.0 (#1119)
- * [57a63e0](https://github.com/tensorchord/envd/commit/57a63e015c813a0a446768b00c83039923ce0df3) chore(deps): bump pypa/cibuildwheel from 2.11.1 to 2.11.2 (#1115)
- * [77b3d84](https://github.com/tensorchord/envd/commit/77b3d84741f990e9cf0b3a8f9bd56abe40fcd895) chore(deps): bump github.com/onsi/gomega from 1.22.1 to 1.23.0 (#1117)
 
 ### Contributors
 
@@ -679,7 +528,6 @@
  * Jinjing Zhou
  * Keming
  * cutecutecat
- * dependabot[bot]
  * nullday
  * tison
  * xieydd
@@ -711,11 +559,6 @@
  * [753fde3](https://github.com/tensorchord/envd/commit/753fde329e7da22837af27cddb48969947b9125b) fix:#1090 (#1092)
  * [1ddd513](https://github.com/tensorchord/envd/commit/1ddd513c03b78b8382d309c3a9fb162ae39973b9) feat(CLI): Support envd-server in up command (#1087)
  * [ab9fe2c](https://github.com/tensorchord/envd/commit/ab9fe2ce255ea18780310f37903b216853386589) feat: Support forward (#1014)
- * [4cd6fef](https://github.com/tensorchord/envd/commit/4cd6fef5d6284538ea523011aac47feec8dcf36a) chore(deps): bump github.com/moby/buildkit from 0.10.4 to 0.10.5 (#1081)
- * [a81bbb0](https://github.com/tensorchord/envd/commit/a81bbb0aab9b1a7d1bf37a0374884f34af386c3b) chore(deps): bump github.com/urfave/cli/v2 from 2.20.2 to 2.20.3 (#1078)
- * [a89f466](https://github.com/tensorchord/envd/commit/a89f466517aec054c0e0c5a295f09b5e7b3c33b7) chore(deps): bump github.com/opencontainers/image-spec from 1.1.0-rc1 to 1.1.0-rc2 (#1077)
- * [a209f79](https://github.com/tensorchord/envd/commit/a209f79d07b945c2a1a87972f191be7f4428d6c1) chore(deps): bump github.com/onsi/gomega from 1.21.1 to 1.22.1 (#1080)
- * [a8a6339](https://github.com/tensorchord/envd/commit/a8a633928a5ec70f5deccbebf81619bb1dbe33da) chore(deps): bump github.com/stretchr/testify from 1.8.0 to 1.8.1 (#1079)
 
 ### Contributors
 
@@ -723,7 +566,6 @@
  * Friends A
  * Jinjing Zhou
  * Yilong Li
- * dependabot[bot]
 
 ## v0.2.4-alpha.15 (2022-10-21)
 
@@ -770,11 +612,6 @@
  * [cf78dd1](https://github.com/tensorchord/envd/commit/cf78dd131e869ad20fe67a4a1159d7bf69e6fb63) feat: Implement env client in envd engine (#1049)
  * [bc6255b](https://github.com/tensorchord/envd/commit/bc6255bc3d494be85afc7c132f2e48f72fffd0fa) example: Add torch profiler example (#1026)
  * [ded3fce](https://github.com/tensorchord/envd/commit/ded3fce1b481aab9c51c2f13dbb2d92288532da0) feat: add `envd down` as an alias for `envd destroy` (#1047)
- * [9b8582d](https://github.com/tensorchord/envd/commit/9b8582d910e83288ef90ba45b599221341ad29f6) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.2.0 to 2.3.1 (#1039)
- * [0ee19ed](https://github.com/tensorchord/envd/commit/0ee19ed79d3332a25082878ca19c1bc032072aef) chore(deps): bump pypa/cibuildwheel from 2.10.2 to 2.11.1 (#1036)
- * [6ba7633](https://github.com/tensorchord/envd/commit/6ba763368d81035b0f13e5eb1549856ecaaa30d1) chore(deps): bump k8s.io/api from 0.25.2 to 0.25.3 (#1038)
- * [0500dca](https://github.com/tensorchord/envd/commit/0500dca9b5174510c1c741ec1d9cfbf97d09a2e9) chore(deps): bump github.com/urfave/cli/v2 from 2.19.2 to 2.20.2 (#1037)
- * [847f187](https://github.com/tensorchord/envd/commit/847f187b45983a56093dd962d5638dae5f260743) chore(deps): bump github.com/onsi/gomega from 1.21.1 to 1.22.1 (#1040)
  * [1fb2721](https://github.com/tensorchord/envd/commit/1fb272197f405c5ee9dcca46c82079095afa406d) bug: Fix flaky auth test (#1034)
  * [d0134d3](https://github.com/tensorchord/envd/commit/d0134d301eba153dcda0c79a3a23babf75a14434) fix(zsh): ignore inserting zsh-completion if system don't have zsh shell (#1025)
  * [ec92a29](https://github.com/tensorchord/envd/commit/ec92a295b835664d559f201ba2542a6a609a560d) feat: support using current directory name as env name in envd describe (#1033)
@@ -784,7 +621,6 @@
  * Ce Gao
  * Jinjing Zhou
  * Zhenzhen Zhao
- * dependabot[bot]
  * wangxiaolei
 
 ## v0.2.4-alpha.10 (2022-10-14)
@@ -801,9 +637,7 @@
  * [46168da](https://github.com/tensorchord/envd/commit/46168dac70fb8cd9b841a32e35a414ad29ddfaa2) chore(test): Add test cases for pkg/home/auth.go (#1009)
  * [d87afda](https://github.com/tensorchord/envd/commit/d87afda9213fcb334ca55d247ba3c0663b7b180b) feat: Add envd-server runtime proposal (#303)
  * [fec7ada](https://github.com/tensorchord/envd/commit/fec7ada4efc2186fa5f858d5abe211a2beb2dfdd) fix: Remove hard code docker in envd engine init (#1000)
- * [cf56f0d](https://github.com/tensorchord/envd/commit/cf56f0de7bfb05be47d4704c14f9bbb892a86d28) chore(deps): bump github.com/onsi/gomega from 1.20.2 to 1.21.1 (#997)
  * [a55470e](https://github.com/tensorchord/envd/commit/a55470e363b35b689649596b449b996ada701630) feat(build): detect if the current environment is running before building (#892) (#989)
- * [d0219f2](https://github.com/tensorchord/envd/commit/d0219f2e3e999e27f334a39180031390a4554af9) chore(deps): bump github.com/urfave/cli/v2 from 2.17.1 to 2.19.2 (#998)
 
 ### Contributors
 
@@ -814,7 +648,6 @@
  * XRW
  * Yijiang Liu
  * Zhenzhen Zhao
- * dependabot[bot]
 
 ## v0.2.4-alpha.9 (2022-10-09)
 
@@ -834,8 +667,6 @@
  * [17fedb8](https://github.com/tensorchord/envd/commit/17fedb8d2ae41318e2f705687c334b7e42413ab3) fix(ir): make sure default value won't be replaced with empty value (#970)
  * [c1ae887](https://github.com/tensorchord/envd/commit/c1ae887f12b23802363ac417c198e19983c5605f) feat(CLI): Support runner in context (#961)
  * [bf993e2](https://github.com/tensorchord/envd/commit/bf993e2cab44502abb74a79e732b74a5567b6194) refact: conda/mamba create/update env, fix user permissions (#933)
- * [0e79fb9](https://github.com/tensorchord/envd/commit/0e79fb91b9f3770f2e5356fc8a10182dd31e2bdf) chore(deps): bump github.com/urfave/cli/v2 from 2.16.3 to 2.17.1 (#968)
- * [c9045d2](https://github.com/tensorchord/envd/commit/c9045d24d412099a1ac0bf9b9acf78135157351d) chore(deps): bump dependabot/fetch-metadata from 1.3.3 to 1.3.4 (#967)
 
 ### Contributors
 
@@ -843,7 +674,6 @@
  * Keming
  * Tumushimire Yves
  * Weizhen Wang
- * dependabot[bot]
 
 ## v0.2.4-alpha.7 (2022-10-01)
 
@@ -890,14 +720,12 @@
 ## v0.2.4-alpha.2 (2022-09-28)
 
  * [b704029](https://github.com/tensorchord/envd/commit/b70402917edf874a0a8e630664b637fa8c22cd53) feat(ir): all in llb (#941)
- * [f5f70e0](https://github.com/tensorchord/envd/commit/f5f70e0de304b8ff4767cd935ab3d307ed5599a2) chore(deps): bump pypa/cibuildwheel from 2.10.1 to 2.10.2 (#936)
  * [bd69c3d](https://github.com/tensorchord/envd/commit/bd69c3df326f1f213472960c099dff0c6d35e41c) feat: Support envd-server (#932)
 
 ### Contributors
 
  * Ce Gao
  * Keming
- * dependabot[bot]
 
 ## v0.2.4-alpha.1 (2022-09-21)
 
@@ -908,9 +736,6 @@
 ## v0.2.4 (2022-10-31)
 
  * [d693254](https://github.com/tensorchord/envd/commit/d693254c1a8b19e02aca85934818a4e7b6dde661) fix: Disable telemetry in CI (#1116)
- * [3cba45e](https://github.com/tensorchord/envd/commit/3cba45e36496cd6010d9b07acbb0c7d34826f828) chore(deps): bump github.com/urfave/cli/v2 from 2.20.3 to 2.23.0 (#1119)
- * [57a63e0](https://github.com/tensorchord/envd/commit/57a63e015c813a0a446768b00c83039923ce0df3) chore(deps): bump pypa/cibuildwheel from 2.11.1 to 2.11.2 (#1115)
- * [77b3d84](https://github.com/tensorchord/envd/commit/77b3d84741f990e9cf0b3a8f9bd56abe40fcd895) chore(deps): bump github.com/onsi/gomega from 1.22.1 to 1.23.0 (#1117)
  * [197b6c6](https://github.com/tensorchord/envd/commit/197b6c612891f0b7bc95b4b1f12a7daacbe7e51f) feat: Add telemetry with the help of segment.io (#1113)
  * [dedd731](https://github.com/tensorchord/envd/commit/dedd73113214d68fd6f8421446fcf2ea8895252e) feat: Add listening_addr to expose fun (#1110)
  * [f672c8f](https://github.com/tensorchord/envd/commit/f672c8f67c9fd793427fb9ec556e767fdf1ef50b) feat: support build time run without mount host (#1109)
@@ -925,11 +750,6 @@
  * [753fde3](https://github.com/tensorchord/envd/commit/753fde329e7da22837af27cddb48969947b9125b) fix:#1090 (#1092)
  * [1ddd513](https://github.com/tensorchord/envd/commit/1ddd513c03b78b8382d309c3a9fb162ae39973b9) feat(CLI): Support envd-server in up command (#1087)
  * [ab9fe2c](https://github.com/tensorchord/envd/commit/ab9fe2ce255ea18780310f37903b216853386589) feat: Support forward (#1014)
- * [4cd6fef](https://github.com/tensorchord/envd/commit/4cd6fef5d6284538ea523011aac47feec8dcf36a) chore(deps): bump github.com/moby/buildkit from 0.10.4 to 0.10.5 (#1081)
- * [a81bbb0](https://github.com/tensorchord/envd/commit/a81bbb0aab9b1a7d1bf37a0374884f34af386c3b) chore(deps): bump github.com/urfave/cli/v2 from 2.20.2 to 2.20.3 (#1078)
- * [a89f466](https://github.com/tensorchord/envd/commit/a89f466517aec054c0e0c5a295f09b5e7b3c33b7) chore(deps): bump github.com/opencontainers/image-spec from 1.1.0-rc1 to 1.1.0-rc2 (#1077)
- * [a209f79](https://github.com/tensorchord/envd/commit/a209f79d07b945c2a1a87972f191be7f4428d6c1) chore(deps): bump github.com/onsi/gomega from 1.21.1 to 1.22.1 (#1080)
- * [a8a6339](https://github.com/tensorchord/envd/commit/a8a633928a5ec70f5deccbebf81619bb1dbe33da) chore(deps): bump github.com/stretchr/testify from 1.8.0 to 1.8.1 (#1079)
  * [9faeebe](https://github.com/tensorchord/envd/commit/9faeebe27f47ce2ee1d99b04325eb41745390099) fix: Fix build.sh (#1072)
  * [ff30b3a](https://github.com/tensorchord/envd/commit/ff30b3a5a4b1ccdc089b601c1d4c2bfdd81ce61c) fix: Fix the file name typo (#1071)
  * [51b00fb](https://github.com/tensorchord/envd/commit/51b00fb189422b4791ef2c53cc80ac3a5067b67a) feat(context): Support unix context and daemonless (#1062)
@@ -943,11 +763,6 @@
  * [cf78dd1](https://github.com/tensorchord/envd/commit/cf78dd131e869ad20fe67a4a1159d7bf69e6fb63) feat: Implement env client in envd engine (#1049)
  * [bc6255b](https://github.com/tensorchord/envd/commit/bc6255bc3d494be85afc7c132f2e48f72fffd0fa) example: Add torch profiler example (#1026)
  * [ded3fce](https://github.com/tensorchord/envd/commit/ded3fce1b481aab9c51c2f13dbb2d92288532da0) feat: add `envd down` as an alias for `envd destroy` (#1047)
- * [9b8582d](https://github.com/tensorchord/envd/commit/9b8582d910e83288ef90ba45b599221341ad29f6) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.2.0 to 2.3.1 (#1039)
- * [0ee19ed](https://github.com/tensorchord/envd/commit/0ee19ed79d3332a25082878ca19c1bc032072aef) chore(deps): bump pypa/cibuildwheel from 2.10.2 to 2.11.1 (#1036)
- * [6ba7633](https://github.com/tensorchord/envd/commit/6ba763368d81035b0f13e5eb1549856ecaaa30d1) chore(deps): bump k8s.io/api from 0.25.2 to 0.25.3 (#1038)
- * [0500dca](https://github.com/tensorchord/envd/commit/0500dca9b5174510c1c741ec1d9cfbf97d09a2e9) chore(deps): bump github.com/urfave/cli/v2 from 2.19.2 to 2.20.2 (#1037)
- * [847f187](https://github.com/tensorchord/envd/commit/847f187b45983a56093dd962d5638dae5f260743) chore(deps): bump github.com/onsi/gomega from 1.21.1 to 1.22.1 (#1040)
  * [1fb2721](https://github.com/tensorchord/envd/commit/1fb272197f405c5ee9dcca46c82079095afa406d) bug: Fix flaky auth test (#1034)
  * [d0134d3](https://github.com/tensorchord/envd/commit/d0134d301eba153dcda0c79a3a23babf75a14434) fix(zsh): ignore inserting zsh-completion if system don't have zsh shell (#1025)
  * [ec92a29](https://github.com/tensorchord/envd/commit/ec92a295b835664d559f201ba2542a6a609a560d) feat: support using current directory name as env name in envd describe (#1033)
@@ -963,9 +778,7 @@
  * [46168da](https://github.com/tensorchord/envd/commit/46168dac70fb8cd9b841a32e35a414ad29ddfaa2) chore(test): Add test cases for pkg/home/auth.go (#1009)
  * [d87afda](https://github.com/tensorchord/envd/commit/d87afda9213fcb334ca55d247ba3c0663b7b180b) feat: Add envd-server runtime proposal (#303)
  * [fec7ada](https://github.com/tensorchord/envd/commit/fec7ada4efc2186fa5f858d5abe211a2beb2dfdd) fix: Remove hard code docker in envd engine init (#1000)
- * [cf56f0d](https://github.com/tensorchord/envd/commit/cf56f0de7bfb05be47d4704c14f9bbb892a86d28) chore(deps): bump github.com/onsi/gomega from 1.20.2 to 1.21.1 (#997)
  * [a55470e](https://github.com/tensorchord/envd/commit/a55470e363b35b689649596b449b996ada701630) feat(build): detect if the current environment is running before building (#892) (#989)
- * [d0219f2](https://github.com/tensorchord/envd/commit/d0219f2e3e999e27f334a39180031390a4554af9) chore(deps): bump github.com/urfave/cli/v2 from 2.17.1 to 2.19.2 (#998)
  * [b2a9018](https://github.com/tensorchord/envd/commit/b2a90188c012fa186de2ecb7b1aa534062681020) feat: Support cli argument for host key (#992)
  * [91ea50c](https://github.com/tensorchord/envd/commit/91ea50cd74e36f2d0d966d2b6a1ddea0ad15c43b) bug: fix pypi package information (#959)
  * [0be9969](https://github.com/tensorchord/envd/commit/0be9969471f8358f1cc283215ddf8e4cfcecebad) fix: Remove dump checkout and remove pre-commit (#982)
@@ -974,8 +787,6 @@
  * [17fedb8](https://github.com/tensorchord/envd/commit/17fedb8d2ae41318e2f705687c334b7e42413ab3) fix(ir): make sure default value won't be replaced with empty value (#970)
  * [c1ae887](https://github.com/tensorchord/envd/commit/c1ae887f12b23802363ac417c198e19983c5605f) feat(CLI): Support runner in context (#961)
  * [bf993e2](https://github.com/tensorchord/envd/commit/bf993e2cab44502abb74a79e732b74a5567b6194) refact: conda/mamba create/update env, fix user permissions (#933)
- * [0e79fb9](https://github.com/tensorchord/envd/commit/0e79fb91b9f3770f2e5356fc8a10182dd31e2bdf) chore(deps): bump github.com/urfave/cli/v2 from 2.16.3 to 2.17.1 (#968)
- * [c9045d2](https://github.com/tensorchord/envd/commit/c9045d24d412099a1ac0bf9b9acf78135157351d) chore(deps): bump dependabot/fetch-metadata from 1.3.3 to 1.3.4 (#967)
  * [c22408c](https://github.com/tensorchord/envd/commit/c22408c8f3b87ef959bda7d7681203ffd8d6212c) fix(ir): `apt install` and `conda env create` cache (#962)
  * [006f653](https://github.com/tensorchord/envd/commit/006f6538396b47b1bcab2a0d53ec9dae0221c8f5) feat: envd-sshd can read public key path from environment variable (#954)
  * [0b73548](https://github.com/tensorchord/envd/commit/0b7354868943f9e4ea189be18eeea534959b5d6c) example: Use torch in mnist example (#927)
@@ -983,14 +794,10 @@
  * [236cd0b](https://github.com/tensorchord/envd/commit/236cd0be8cdfa9e4731d3b69cec7027001c8770b) fix: version tag in build.sh (#947)
  * [2eef587](https://github.com/tensorchord/envd/commit/2eef587b44dfe77828570bac8a3e2a7def61c5e1) fix: r & julia sshd image (#945)
  * [b704029](https://github.com/tensorchord/envd/commit/b70402917edf874a0a8e630664b637fa8c22cd53) feat(ir): all in llb (#941)
- * [f5f70e0](https://github.com/tensorchord/envd/commit/f5f70e0de304b8ff4767cd935ab3d307ed5599a2) chore(deps): bump pypa/cibuildwheel from 2.10.1 to 2.10.2 (#936)
  * [bd69c3d](https://github.com/tensorchord/envd/commit/bd69c3df326f1f213472960c099dff0c6d35e41c) feat: Support envd-server (#932)
  * [171b82f](https://github.com/tensorchord/envd/commit/171b82fcbac1da9543b9acda1911d110c322d802) fix: e2e doc test (#926)
  * [ce36545](https://github.com/tensorchord/envd/commit/ce36545d4865a6062ab4b6332a0e26e0d7030db2) feat(cli): rm image when destroying the env (#925)
  * [eecc7cf](https://github.com/tensorchord/envd/commit/eecc7cf48cf354ef3d72f17dfcf1d6f19bf90b85) feat: informative error message (#859)
- * [a3fd464](https://github.com/tensorchord/envd/commit/a3fd4649f83f95d4e349348e4367bf564447780f) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.1.6 to 2.2.0 (#919)
- * [756c92d](https://github.com/tensorchord/envd/commit/756c92d48cb819149be5520948de122b687a25aa) chore(deps): bump github.com/urfave/cli/v2 from 2.16.2 to 2.16.3 (#918)
- * [b5acc08](https://github.com/tensorchord/envd/commit/b5acc08d46b6b84a0c57d19a2e1b62e247785bd4) chore(deps): bump pypa/cibuildwheel from 2.9.0 to 2.10.1 (#917)
 
 ### Contributors
 
@@ -1005,7 +812,6 @@
  * Yijiang Liu
  * Yilong Li
  * Zhenzhen Zhao
- * dependabot[bot]
  * nullday
  * wangxiaolei
 
@@ -1031,60 +837,6 @@
 ### Contributors
 
 
-## v0.2.0-beta.1 (2022-09-27)
-
-
-### Contributors
-
-
-## v0.2.0-beta6 (2022-09-28)
-
- * [9046f3b](https://github.com/tensorchord/envd/commit/9046f3b1e0bd6e990e0b651584d042a585fd17c8) fix gorlease v
- * [9fea9e8](https://github.com/tensorchord/envd/commit/9fea9e8b1944acf82ac81d07874d7b2d22b4ce97) cache gpu
- * [c7917a6](https://github.com/tensorchord/envd/commit/c7917a607553338b58a4d40af1a3262cd5618bb8) use git tag
- * [c5aeec6](https://github.com/tensorchord/envd/commit/c5aeec6ee82fdeb2d6da2ecc0f5d3baf1093e918) fix ref bug
-
-### Contributors
-
- * Keming
-
-## v0.2.0-beta5 (2022-09-27)
-
- * [86f0b17](https://github.com/tensorchord/envd/commit/86f0b170902275d9320de819cfd708d6fd797015) fix ci secret
-
-### Contributors
-
- * Keming
-
-## v0.2.0-beta4 (2022-09-27)
-
- * [5cb30f3](https://github.com/tensorchord/envd/commit/5cb30f33067c3334435ade69a5c082a870a63a70) only run some ci in tensorchord
- * [cfefb15](https://github.com/tensorchord/envd/commit/cfefb15c7120b04bb711ee4a7f84e0803fbae487) fix ci yml
- * [84c80be](https://github.com/tensorchord/envd/commit/84c80be8cb4f753a2131fa671569925bd9c1bf7f) fix ci
- * [cea390d](https://github.com/tensorchord/envd/commit/cea390ddf1a61358ade9cebbe2f4fdc71a7233fe) del python dockerfile
- * [2a45a8f](https://github.com/tensorchord/envd/commit/2a45a8f2f918288c3d862597c4c94566f9138773) cuda version
- * [5e407d0](https://github.com/tensorchord/envd/commit/5e407d0eb1a73cac86721b66c2bed290d35ac76e) delete outdated comments
- * [16ca22f](https://github.com/tensorchord/envd/commit/16ca22f7d2e1f02060f299c4a69c74db647ef843) add llb log
- * [7327c13](https://github.com/tensorchord/envd/commit/7327c13c32ff897160b40e49eb70b884589b5bd1) copy envd-sshd
- * [f58e55b](https://github.com/tensorchord/envd/commit/f58e55ba4b52b7b9efa1a4669e5f5b11b364b7a0) change to docker hub
- * [0863ac5](https://github.com/tensorchord/envd/commit/0863ac5c6ea050dd5832d54c6dd90f80b5adf3d4) change python dockerfile to llb
- * [bd69c3d](https://github.com/tensorchord/envd/commit/bd69c3df326f1f213472960c099dff0c6d35e41c) feat: Support envd-server (#932)
- * [171b82f](https://github.com/tensorchord/envd/commit/171b82fcbac1da9543b9acda1911d110c322d802) fix: e2e doc test (#926)
- * [ce36545](https://github.com/tensorchord/envd/commit/ce36545d4865a6062ab4b6332a0e26e0d7030db2) feat(cli): rm image when destroying the env (#925)
- * [eecc7cf](https://github.com/tensorchord/envd/commit/eecc7cf48cf354ef3d72f17dfcf1d6f19bf90b85) feat: informative error message (#859)
- * [a3fd464](https://github.com/tensorchord/envd/commit/a3fd4649f83f95d4e349348e4367bf564447780f) chore(deps): bump github.com/onsi/ginkgo/v2 from 2.1.6 to 2.2.0 (#919)
- * [756c92d](https://github.com/tensorchord/envd/commit/756c92d48cb819149be5520948de122b687a25aa) chore(deps): bump github.com/urfave/cli/v2 from 2.16.2 to 2.16.3 (#918)
- * [b5acc08](https://github.com/tensorchord/envd/commit/b5acc08d46b6b84a0c57d19a2e1b62e247785bd4) chore(deps): bump pypa/cibuildwheel from 2.9.0 to 2.10.1 (#917)
- * [c3c0b4e](https://github.com/tensorchord/envd/commit/c3c0b4e33ab696c3863632d0d4179f8211813fcb) fix: Use macos 11 (#912)
- * [6721a88](https://github.com/tensorchord/envd/commit/6721a88aa1e2a97bfd3060e3168ab15b61f25609) chore(goreleaser): Skip homebrew (#909)
-
-### Contributors
-
- * Ce Gao
- * Jinjing Zhou
- * Keming
- * dependabot[bot]
-
 ## v0.2.0-alpha.22 (2022-09-16)
 
  * [4707bfe](https://github.com/tensorchord/envd/commit/4707bfeaea030a48c5601bffb87ff034e4d1b413)  fix: Fix jupyter in root (#900)
@@ -1094,30 +846,16 @@
  * [2e8b5d5](https://github.com/tensorchord/envd/commit/2e8b5d5d4756b5c02c6d3e846b5be093fd6394b1) fix: include update repo (#885)
  * [eb2cdd1](https://github.com/tensorchord/envd/commit/eb2cdd1a65321a1530f59190cd40560e6c31d5a3) bug: Fix detach instruction message (#882)
  * [8a02b26](https://github.com/tensorchord/envd/commit/8a02b264ac16318c5d54660ca883414ef7a15cad) refact: add envd home path func (#880)
- * [63daa5e](https://github.com/tensorchord/envd/commit/63daa5e870e5ea24c3f6e881e4932da2334688dc) chore(deps): bump github.com/spf13/viper from 1.12.0 to 1.13.0 (#875)
- * [aa53bdb](https://github.com/tensorchord/envd/commit/aa53bdb478645863dae60ca37f1ebdbc7a564c56) chore(deps): bump github.com/urfave/cli/v2 from 2.14.0 to 2.16.2 (#874)
 
 ### Contributors
 
  * Ce Gao
  * Jinjing Zhou
  * Keming
- * dependabot[bot]
 
 ## v0.2.0-alpha.21 (2022-09-12)
 
- * [ddf3bdc](https://github.com/tensorchord/envd/commit/ddf3bdc8dd859683d7539d3c7f226b82cece40e7) chore(deps): bump actions/setup-go from 2 to 3 (#873)
- * [7220958](https://github.com/tensorchord/envd/commit/72209583b941c4eb87b282004f7c8a1ae57410ae) chore(deps): bump actions/checkout from 2 to 3 (#872)
  * [f1b3fe5](https://github.com/tensorchord/envd/commit/f1b3fe5029091cffc0a1022b665d585132c5a8d8) chore(CLI): test new release for envd-sshd (#866)
-
-### Contributors
-
- * Yuedong Wu
- * dependabot[bot]
-
-## v0.2.0-alpha.20 (2022-09-11)
-
- * [b38c5de](https://github.com/tensorchord/envd/commit/b38c5de82aac50fe085cd48d2111f7f5d241b6d7) chore(CLI): test new release for envd-sshd (#866)
  * [49d79fb](https://github.com/tensorchord/envd/commit/49d79fb17bee4a2baaeadd500607cba7d8426b28) fix: Update readme (#865)
  * [d7995a7](https://github.com/tensorchord/envd/commit/d7995a7171cbe48a65aad3e3b56077ffee9a625a) feat(lang): io.http download files to extra_source (#858)
  * [0d3b42f](https://github.com/tensorchord/envd/commit/0d3b42fe4f33241742986030a45431a5f068dc75) feat: Support HTTP PROXY (#857)
@@ -1135,20 +873,15 @@
  * [ecb9e26](https://github.com/tensorchord/envd/commit/ecb9e2626e65b5e1f647d7385142c10677f2d7eb) refact: unify the path env (#855)
  * [8056fda](https://github.com/tensorchord/envd/commit/8056fda28febfe6cbe64502159b302b670970517) feat: add runtime graph to image label (#815)
  * [6ad1d4c](https://github.com/tensorchord/envd/commit/6ad1d4ca2085317850e9726910bc3024b743439e) refact: apt_source, io, config mode (#853)
- * [07e2dc0](https://github.com/tensorchord/envd/commit/07e2dc0e6d4d7f3be2debf79389a792964e727b1) chore(deps): bump github.com/gliderlabs/ssh from 0.3.4 to 0.3.5 (#849)
 
 ### Contributors
 
  * Jinjing Zhou
  * Keming
- * dependabot[bot]
  * nullday
 
 ## v0.2.0-alpha.18 (2022-09-06)
 
- * [c0ba31a](https://github.com/tensorchord/envd/commit/c0ba31adc231d09600892f9445320df8eb84947b) chore(deps): bump github.com/onsi/gomega from 1.20.1 to 1.20.2 (#846)
- * [13bc9a6](https://github.com/tensorchord/envd/commit/13bc9a61c4255215661c724fb7c54f2b81642a21) chore(deps): bump github.com/urfave/cli/v2 from 2.11.2 to 2.14.0 (#845)
- * [11966f8](https://github.com/tensorchord/envd/commit/11966f8c0f997f57c45979d7857cac48ad1d1e5b) chore(deps): bump github.com/docker/go-units from 0.4.0 to 0.5.0 (#848)
  * [7ba3b3f](https://github.com/tensorchord/envd/commit/7ba3b3fa6b716efd3398a7cb3e533e915129717d) feat(cli): add msg when detach from container (#841)
  * [7fc9f34](https://github.com/tensorchord/envd/commit/7fc9f34d333b22013e847fd2c2312d18fb861068) fix: Update demo (#840)
  * [190ee76](https://github.com/tensorchord/envd/commit/190ee7635f0d9bbdee6c8b53d53a72dd8ca4e619) feat(lang): install.python_packages(local_wheels=[]) (#838)
@@ -1158,15 +891,12 @@
  * [404de31](https://github.com/tensorchord/envd/commit/404de3101cece0497084412433cf877f66cf5ee2) feat(lang): init py env by generating the bulid.envd (#827)
  * [36b1231](https://github.com/tensorchord/envd/commit/36b123142385d20fb7f7c1106c15c02f79ed4742) bug: fix permission issue when pip install from git repo (#829)
  * [1dcada4](https://github.com/tensorchord/envd/commit/1dcada4403d0c0bf8e916fc67b62c174f66df3d3) feat(build): Mount local build context into the run command (#822)
- * [f70a11c](https://github.com/tensorchord/envd/commit/f70a11c5f251b8ed0f0f42cd422b4b93efabd4a7) chore(deps): bump github.com/onsi/gomega from 1.20.0 to 1.20.1 (#821)
- * [3b440c6](https://github.com/tensorchord/envd/commit/3b440c60c59ee65444a92aa91e295be9be2125b0) chore(deps): bump github.com/moby/buildkit from 0.10.3 to 0.10.4 (#820)
 
 ### Contributors
 
  * Ce Gao
  * Jinjing Zhou
  * Keming
- * dependabot[bot]
 
 ## v0.2.0-alpha.17 (2022-08-26)
 
@@ -1208,8 +938,6 @@
  * [2f82fa5](https://github.com/tensorchord/envd/commit/2f82fa5ab884671ba2a5058d38d205cbd20bce1f) proposal: daemon process (#769)
  * [d06b878](https://github.com/tensorchord/envd/commit/d06b8786e2963f4bf5cc92b90fdcc80621a4bd5e) doc: update python api doc (#759)
  * [ce2e8b2](https://github.com/tensorchord/envd/commit/ce2e8b2b4e755b52892d9b3597489daae19f1dad) fix: Remove empty token arg (#772)
- * [8ab89b9](https://github.com/tensorchord/envd/commit/8ab89b967caa104ad839a83d7d9ece186eb80918) chore(deps): bump github.com/urfave/cli/v2 from 2.11.1 to 2.11.2 (#775)
- * [3a6b127](https://github.com/tensorchord/envd/commit/3a6b12772b956eb31b6ccc6c31e62efbc3feb6e3) chore(deps): bump pypa/cibuildwheel from 2.8.1 to 2.9.0 (#774)
  * [ec8cae1](https://github.com/tensorchord/envd/commit/ec8cae17b26de61bbb73026540db56505cffb2a8) fix: remove unnecessary if statement (#773)
 
 ### Contributors
@@ -1218,7 +946,6 @@
  * Keming
  * Wei Zhang
  * Zhizhen He
- * dependabot[bot]
 
 ## v0.2.0-alpha.14 (2022-08-12)
 
@@ -1313,11 +1040,6 @@
  * [b3ee633](https://github.com/tensorchord/envd/commit/b3ee6334a54e7d89b3f2631631c112c1d5ecac6a) fix: Fix lint issues in conda env yaml feature PR (#679)
  * [a796a12](https://github.com/tensorchord/envd/commit/a796a129d83e5c707bb9d0c1c32295208b136495) feat(lang): Support env.yaml in conda_packages (#674)
  * [af3e78d](https://github.com/tensorchord/envd/commit/af3e78d6733f53f5d31eda045725c0af599aefa6) feature:  add label ai.tensorchord.envd.build.manifestBytecodeHash to image for cache robust (#661)
- * [3044002](https://github.com/tensorchord/envd/commit/30440022266b908adbb790e59c6696b36bf92b28) chore(deps): bump github.com/onsi/gomega from 1.19.0 to 1.20.0 (#657)
- * [400fd7f](https://github.com/tensorchord/envd/commit/400fd7f8af0a04d1d0aa5fd7f047fea59172a7ef) chore(deps): bump github.com/urfave/cli/v2 from 2.11.0 to 2.11.1 (#655)
- * [30e8caf](https://github.com/tensorchord/envd/commit/30e8cafc80b04b1bfa6e4d9d2ba273928c8b3919) chore(deps): bump actions/upload-artifact from 2 to 3 (#654)
- * [04360d6](https://github.com/tensorchord/envd/commit/04360d63ba984a1a58faaf300d0cee64269d442a) chore(deps): bump pypa/cibuildwheel from 2.8.0 to 2.8.1 (#653)
- * [de6c59e](https://github.com/tensorchord/envd/commit/de6c59e730da4520bccc747bb941bb12ced913d7) chore(deps): bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0 (#656)
  * [62091a4](https://github.com/tensorchord/envd/commit/62091a460b5502d24fa57a04ad19cf273c832832) fix(build): Fix image config (#651)
  * [4c1df28](https://github.com/tensorchord/envd/commit/4c1df286df7c3d5c4a99b4bbc5958f86d08e0738) fix: context create with 'use' (#652)
  * [6f05072](https://github.com/tensorchord/envd/commit/6f05072f1f2a72b55d8e2bac468707219ceb30b4) feat(CLI): Support cache (#648)
@@ -1327,7 +1049,6 @@
 
  * Ce Gao
  * Keming
- * dependabot[bot]
  * nullday
  * wyq
 
@@ -1337,13 +1058,11 @@
  * [890119d](https://github.com/tensorchord/envd/commit/890119d119e7becf9f39f392aa053ae1e70c77c0) fix: check manifest and image update in new gateway buildfunc (#624)
  * [c8471db](https://github.com/tensorchord/envd/commit/c8471db20f0a7e48c2c8346b3ab88637445200f5) support buildkit TCP socket (#599)
  * [ef8a90d](https://github.com/tensorchord/envd/commit/ef8a90df3bc1a3009381eb3fd10767f468fcefc2) feat: Refactor with Builder.Options (#615)
- * [2a88ad1](https://github.com/tensorchord/envd/commit/2a88ad120b2a24b5095883a1e18de55189ff643f) chore(deps): bump github.com/urfave/cli/v2 from 2.10.3 to 2.11.0 (#610)
 
 ### Contributors
 
  * Ce Gao
  * Keming
- * dependabot[bot]
  * nullday
 
 ## v0.2.0-alpha.6 (2022-07-15)
@@ -1357,14 +1076,12 @@
  * [fa041a8](https://github.com/tensorchord/envd/commit/fa041a849dde7f61f82fa2afdf105e45efc888ef) fix: Pre-mkdir the .cache directory of user envd (#592)
  * [54dfc52](https://github.com/tensorchord/envd/commit/54dfc52f4adc5cbce5de806dc6186e39adf21e0d) bug: fix missing function in example mnist (#589)
  * [00249bb](https://github.com/tensorchord/envd/commit/00249bbd2330088dc584015353837917bd557503) Use DefaultText in up.go (#587)
- * [302e449](https://github.com/tensorchord/envd/commit/302e4490992d5f74bf5a9e08293cfb42a89e0367) chore(deps): bump pypa/cibuildwheel from 2.7.0 to 2.8.0 (#583)
 
 ### Contributors
 
  * Ce Gao
  * Guangyang Li
  * Jinjing Zhou
- * dependabot[bot]
  * nullday
 
 ## v0.2.0-alpha.5 (2022-07-08)
@@ -1390,14 +1107,11 @@
 
  * [6e9e44d](https://github.com/tensorchord/envd/commit/6e9e44dfadf13c3899707beda09d92b4f907e24d) feat: Support specify build target (#497)
  * [e443784](https://github.com/tensorchord/envd/commit/e44378470ddd029e3f2c94c93e00b0399e89b772) feat(lang): Support RStudio server (#503)
- * [89eb6e8](https://github.com/tensorchord/envd/commit/89eb6e8b5bdf795f2f1b145b75b6d87745284d71) chore(deps): bump github.com/stretchr/testify from 1.7.5 to 1.8.0 (#540)
- * [74b27e9](https://github.com/tensorchord/envd/commit/74b27e9d0039c2558b3ebd152260f0c163fc7d37) chore(deps): bump dependabot/fetch-metadata from 1.3.1 to 1.3.3 (#539)
 
 ### Contributors
 
  * Ce Gao
  * Jinjing Zhou
- * dependabot[bot]
 
 ## v0.2.0-alpha.3 (2022-07-01)
 
@@ -1443,10 +1157,6 @@
  * [2e8b5d5](https://github.com/tensorchord/envd/commit/2e8b5d5d4756b5c02c6d3e846b5be093fd6394b1) fix: include update repo (#885)
  * [eb2cdd1](https://github.com/tensorchord/envd/commit/eb2cdd1a65321a1530f59190cd40560e6c31d5a3) bug: Fix detach instruction message (#882)
  * [8a02b26](https://github.com/tensorchord/envd/commit/8a02b264ac16318c5d54660ca883414ef7a15cad) refact: add envd home path func (#880)
- * [63daa5e](https://github.com/tensorchord/envd/commit/63daa5e870e5ea24c3f6e881e4932da2334688dc) chore(deps): bump github.com/spf13/viper from 1.12.0 to 1.13.0 (#875)
- * [aa53bdb](https://github.com/tensorchord/envd/commit/aa53bdb478645863dae60ca37f1ebdbc7a564c56) chore(deps): bump github.com/urfave/cli/v2 from 2.14.0 to 2.16.2 (#874)
- * [ddf3bdc](https://github.com/tensorchord/envd/commit/ddf3bdc8dd859683d7539d3c7f226b82cece40e7) chore(deps): bump actions/setup-go from 2 to 3 (#873)
- * [7220958](https://github.com/tensorchord/envd/commit/72209583b941c4eb87b282004f7c8a1ae57410ae) chore(deps): bump actions/checkout from 2 to 3 (#872)
  * [f1b3fe5](https://github.com/tensorchord/envd/commit/f1b3fe5029091cffc0a1022b665d585132c5a8d8) chore(CLI): test new release for envd-sshd (#866)
  * [49d79fb](https://github.com/tensorchord/envd/commit/49d79fb17bee4a2baaeadd500607cba7d8426b28) fix: Update readme (#865)
  * [d7995a7](https://github.com/tensorchord/envd/commit/d7995a7171cbe48a65aad3e3b56077ffee9a625a) feat(lang): io.http download files to extra_source (#858)
@@ -1456,10 +1166,6 @@
  * [ecb9e26](https://github.com/tensorchord/envd/commit/ecb9e2626e65b5e1f647d7385142c10677f2d7eb) refact: unify the path env (#855)
  * [8056fda](https://github.com/tensorchord/envd/commit/8056fda28febfe6cbe64502159b302b670970517) feat: add runtime graph to image label (#815)
  * [6ad1d4c](https://github.com/tensorchord/envd/commit/6ad1d4ca2085317850e9726910bc3024b743439e) refact: apt_source, io, config mode (#853)
- * [07e2dc0](https://github.com/tensorchord/envd/commit/07e2dc0e6d4d7f3be2debf79389a792964e727b1) chore(deps): bump github.com/gliderlabs/ssh from 0.3.4 to 0.3.5 (#849)
- * [c0ba31a](https://github.com/tensorchord/envd/commit/c0ba31adc231d09600892f9445320df8eb84947b) chore(deps): bump github.com/onsi/gomega from 1.20.1 to 1.20.2 (#846)
- * [13bc9a6](https://github.com/tensorchord/envd/commit/13bc9a61c4255215661c724fb7c54f2b81642a21) chore(deps): bump github.com/urfave/cli/v2 from 2.11.2 to 2.14.0 (#845)
- * [11966f8](https://github.com/tensorchord/envd/commit/11966f8c0f997f57c45979d7857cac48ad1d1e5b) chore(deps): bump github.com/docker/go-units from 0.4.0 to 0.5.0 (#848)
  * [7ba3b3f](https://github.com/tensorchord/envd/commit/7ba3b3fa6b716efd3398a7cb3e533e915129717d) feat(cli): add msg when detach from container (#841)
  * [7fc9f34](https://github.com/tensorchord/envd/commit/7fc9f34d333b22013e847fd2c2312d18fb861068) fix: Update demo (#840)
  * [190ee76](https://github.com/tensorchord/envd/commit/190ee7635f0d9bbdee6c8b53d53a72dd8ca4e619) feat(lang): install.python_packages(local_wheels=[]) (#838)
@@ -1469,8 +1175,6 @@
  * [404de31](https://github.com/tensorchord/envd/commit/404de3101cece0497084412433cf877f66cf5ee2) feat(lang): init py env by generating the bulid.envd (#827)
  * [36b1231](https://github.com/tensorchord/envd/commit/36b123142385d20fb7f7c1106c15c02f79ed4742) bug: fix permission issue when pip install from git repo (#829)
  * [1dcada4](https://github.com/tensorchord/envd/commit/1dcada4403d0c0bf8e916fc67b62c174f66df3d3) feat(build): Mount local build context into the run command (#822)
- * [f70a11c](https://github.com/tensorchord/envd/commit/f70a11c5f251b8ed0f0f42cd422b4b93efabd4a7) chore(deps): bump github.com/onsi/gomega from 1.20.0 to 1.20.1 (#821)
- * [3b440c6](https://github.com/tensorchord/envd/commit/3b440c60c59ee65444a92aa91e295be9be2125b0) chore(deps): bump github.com/moby/buildkit from 0.10.3 to 0.10.4 (#820)
  * [82fbc87](https://github.com/tensorchord/envd/commit/82fbc87ade5637fe7db8e2c0087a1555206dc1b1) doc: add include, refine others (#817)
  * [630ada1](https://github.com/tensorchord/envd/commit/630ada172bdf876c3b749329fdbe284c108051f2) feat(lang): support include other git repo for envd functions/variables (#808)
  * [5c4971b](https://github.com/tensorchord/envd/commit/5c4971b2f5fa6b32c2c247e18cf6c6a178d28f57) feat(CLI): envd env describe expose info (#801)
@@ -1490,8 +1194,6 @@
  * [2f82fa5](https://github.com/tensorchord/envd/commit/2f82fa5ab884671ba2a5058d38d205cbd20bce1f) proposal: daemon process (#769)
  * [d06b878](https://github.com/tensorchord/envd/commit/d06b8786e2963f4bf5cc92b90fdcc80621a4bd5e) doc: update python api doc (#759)
  * [ce2e8b2](https://github.com/tensorchord/envd/commit/ce2e8b2b4e755b52892d9b3597489daae19f1dad) fix: Remove empty token arg (#772)
- * [8ab89b9](https://github.com/tensorchord/envd/commit/8ab89b967caa104ad839a83d7d9ece186eb80918) chore(deps): bump github.com/urfave/cli/v2 from 2.11.1 to 2.11.2 (#775)
- * [3a6b127](https://github.com/tensorchord/envd/commit/3a6b12772b956eb31b6ccc6c31e62efbc3feb6e3) chore(deps): bump pypa/cibuildwheel from 2.8.1 to 2.9.0 (#774)
  * [ec8cae1](https://github.com/tensorchord/envd/commit/ec8cae17b26de61bbb73026540db56505cffb2a8) fix: remove unnecessary if statement (#773)
  * [b9f0af8](https://github.com/tensorchord/envd/commit/b9f0af8056129fe6c5a2e590cd428463186cac0e) fix: -path and -file bug (#766)
  * [4a359f1](https://github.com/tensorchord/envd/commit/4a359f1eb608a0680a94379b4ac52756d605be9d) fix(release): :hammer: drop go build dep for homebrew (#768)
@@ -1535,11 +1237,6 @@
  * [b3ee633](https://github.com/tensorchord/envd/commit/b3ee6334a54e7d89b3f2631631c112c1d5ecac6a) fix: Fix lint issues in conda env yaml feature PR (#679)
  * [a796a12](https://github.com/tensorchord/envd/commit/a796a129d83e5c707bb9d0c1c32295208b136495) feat(lang): Support env.yaml in conda_packages (#674)
  * [af3e78d](https://github.com/tensorchord/envd/commit/af3e78d6733f53f5d31eda045725c0af599aefa6) feature:  add label ai.tensorchord.envd.build.manifestBytecodeHash to image for cache robust (#661)
- * [3044002](https://github.com/tensorchord/envd/commit/30440022266b908adbb790e59c6696b36bf92b28) chore(deps): bump github.com/onsi/gomega from 1.19.0 to 1.20.0 (#657)
- * [400fd7f](https://github.com/tensorchord/envd/commit/400fd7f8af0a04d1d0aa5fd7f047fea59172a7ef) chore(deps): bump github.com/urfave/cli/v2 from 2.11.0 to 2.11.1 (#655)
- * [30e8caf](https://github.com/tensorchord/envd/commit/30e8cafc80b04b1bfa6e4d9d2ba273928c8b3919) chore(deps): bump actions/upload-artifact from 2 to 3 (#654)
- * [04360d6](https://github.com/tensorchord/envd/commit/04360d63ba984a1a58faaf300d0cee64269d442a) chore(deps): bump pypa/cibuildwheel from 2.8.0 to 2.8.1 (#653)
- * [de6c59e](https://github.com/tensorchord/envd/commit/de6c59e730da4520bccc747bb941bb12ced913d7) chore(deps): bump github.com/sirupsen/logrus from 1.8.1 to 1.9.0 (#656)
  * [62091a4](https://github.com/tensorchord/envd/commit/62091a460b5502d24fa57a04ad19cf273c832832) fix(build): Fix image config (#651)
  * [4c1df28](https://github.com/tensorchord/envd/commit/4c1df286df7c3d5c4a99b4bbc5958f86d08e0738) fix: context create with 'use' (#652)
  * [6f05072](https://github.com/tensorchord/envd/commit/6f05072f1f2a72b55d8e2bac468707219ceb30b4) feat(CLI): Support cache (#648)
@@ -1548,7 +1245,6 @@
  * [890119d](https://github.com/tensorchord/envd/commit/890119d119e7becf9f39f392aa053ae1e70c77c0) fix: check manifest and image update in new gateway buildfunc (#624)
  * [c8471db](https://github.com/tensorchord/envd/commit/c8471db20f0a7e48c2c8346b3ab88637445200f5) support buildkit TCP socket (#599)
  * [ef8a90d](https://github.com/tensorchord/envd/commit/ef8a90df3bc1a3009381eb3fd10767f468fcefc2) feat: Refactor with Builder.Options (#615)
- * [2a88ad1](https://github.com/tensorchord/envd/commit/2a88ad120b2a24b5095883a1e18de55189ff643f) chore(deps): bump github.com/urfave/cli/v2 from 2.10.3 to 2.11.0 (#610)
  * [18abe90](https://github.com/tensorchord/envd/commit/18abe90072835534f75b392b5f1ef6dbbf0bbeb5) feat(builder): Abstract BuildFunc to use gateway client (#606)
  * [178b8da](https://github.com/tensorchord/envd/commit/178b8dafdd4357688a911bfff103c397b08410a9) feat(WSL): Add ssh config entry to Windows ssh config if using WSL (#604)
  * [ceb07f5](https://github.com/tensorchord/envd/commit/ceb07f5fc43ced6da9ada711eb8c127d14afa969) fix: set conda as the only python provider (#602)
@@ -1558,7 +1254,6 @@
  * [fa041a8](https://github.com/tensorchord/envd/commit/fa041a849dde7f61f82fa2afdf105e45efc888ef) fix: Pre-mkdir the .cache directory of user envd (#592)
  * [54dfc52](https://github.com/tensorchord/envd/commit/54dfc52f4adc5cbce5de806dc6186e39adf21e0d) bug: fix missing function in example mnist (#589)
  * [00249bb](https://github.com/tensorchord/envd/commit/00249bbd2330088dc584015353837917bd557503) Use DefaultText in up.go (#587)
- * [302e449](https://github.com/tensorchord/envd/commit/302e4490992d5f74bf5a9e08293cfb42a89e0367) chore(deps): bump pypa/cibuildwheel from 2.7.0 to 2.8.0 (#583)
  * [6cfc0f1](https://github.com/tensorchord/envd/commit/6cfc0f16224095605dd85fb38b9cf406fbb65118) feat: Support for build image update when exec build or up again (#570)
  * [8f89e4b](https://github.com/tensorchord/envd/commit/8f89e4be3d154728824c67f13086eb727f545400) Fix: image tag normalized to docker spec (#573)
  * [3fe3757](https://github.com/tensorchord/envd/commit/3fe375769487a4eaf224a6db1437c840002c7a15) fix: add -c for every single conda channel (#569)
@@ -1569,8 +1264,6 @@
  * [f71cd7f](https://github.com/tensorchord/envd/commit/f71cd7f4891fab5e1be588e9b991ab4942e02d57) feat(CLI): Unify CLI style about env and image (#550)
  * [6e9e44d](https://github.com/tensorchord/envd/commit/6e9e44dfadf13c3899707beda09d92b4f907e24d) feat: Support specify build target (#497)
  * [e443784](https://github.com/tensorchord/envd/commit/e44378470ddd029e3f2c94c93e00b0399e89b772) feat(lang): Support RStudio server (#503)
- * [89eb6e8](https://github.com/tensorchord/envd/commit/89eb6e8b5bdf795f2f1b145b75b6d87745284d71) chore(deps): bump github.com/stretchr/testify from 1.7.5 to 1.8.0 (#540)
- * [74b27e9](https://github.com/tensorchord/envd/commit/74b27e9d0039c2558b3ebd152260f0c163fc7d37) chore(deps): bump dependabot/fetch-metadata from 1.3.1 to 1.3.3 (#539)
  * [dbac24d](https://github.com/tensorchord/envd/commit/dbac24d7931832d0fed12e931e544d31a557626d) feat(docker): Add entrypoint and ports in image config (#533)
  * [60f85f5](https://github.com/tensorchord/envd/commit/60f85f53c62597bc47f9d4328bb071b9795e0474) fix(README): Update coverage (#536)
  * [8276d7d](https://github.com/tensorchord/envd/commit/8276d7da92658a2d885a00c5039a87fb78cb2376) feat(CLI): Add push (#531)
@@ -1581,8 +1274,6 @@
  * [523fb40](https://github.com/tensorchord/envd/commit/523fb400742ed5b539f44232d9eedad8eaefd13c) feat(CLI): Support context (#512)
  * [fde448a](https://github.com/tensorchord/envd/commit/fde448aff613306cb5ff3d763c06f05de12ec338) feat: add envd init (#514)
  * [8722564](https://github.com/tensorchord/envd/commit/8722564b12f0c96c58fca5d912c7c9c2e57c77a6) enhancement(CLI): Use upper case in CLI description (#515)
- * [0ae8df9](https://github.com/tensorchord/envd/commit/0ae8df9e9eb4ec0c755920a7a3697cbab12b22e3) chore(deps): bump github.com/stretchr/testify from 1.7.2 to 1.7.5 (#505)
- * [1cd5a27](https://github.com/tensorchord/envd/commit/1cd5a27027dd696276fa75e1d52a02858b7e7de8) chore(deps): bump github.com/urfave/cli/v2 from 2.8.1 to 2.10.3 (#504)
  * [ca6435d](https://github.com/tensorchord/envd/commit/ca6435ddfd29f5be2e85a1039da50c4db2fea03f) feat(lang): Support julia (#495)
  * [220d874](https://github.com/tensorchord/envd/commit/220d874712d7f7120f16337324d23b440163e3f7) feat(ssh): Config ssh key permanently and globally (#487)
  * [7127365](https://github.com/tensorchord/envd/commit/7127365e47c6a2923ce93ecf0164df49810b13fc) feat(lang): Support R language (#491)
@@ -1618,7 +1309,6 @@
  * Zhenguo.Li
  * Zhenzhen Zhao
  * Zhizhen He
- * dependabot[bot]
  * kenwoodjw
  * nullday
  * wyq
@@ -1640,10 +1330,6 @@
  * [6e1cf05](https://github.com/tensorchord/envd/commit/6e1cf0509844060040bbd85d4f19e29410fb7a6f) fix: replace useless .editorconfig (#440)
  * [1c23cea](https://github.com/tensorchord/envd/commit/1c23cea84bfb37f2cd5ee0df63bf625448147994) release: Separate alpha and stable release in Homebrew (#439)
  * [274e183](https://github.com/tensorchord/envd/commit/274e18317597bb7a7a6413f59a52e7d5274ac85c) Update PyTorch installation CMD in examples (#435)
- * [cfda1be](https://github.com/tensorchord/envd/commit/cfda1bed6f9861f198d0a37ebc8f46ed4bbb51ab) chore(deps): bump pypa/cibuildwheel from 2.6.1 to 2.7.0 (#428)
- * [d25157e](https://github.com/tensorchord/envd/commit/d25157ef8169f2aa7c7169dfa18b389041a036a0) chore(deps): bump github.com/spf13/viper from 1.4.0 to 1.12.0 (#430)
- * [d394410](https://github.com/tensorchord/envd/commit/d394410331eb25d20a33b6adef68506cbc0b6602) chore(deps): bump goreleaser/goreleaser-action from 2 to 3 (#427)
- * [7070506](https://github.com/tensorchord/envd/commit/7070506f6c2acb44692dd06090ec9d614927ef65) chore(deps): bump github.com/gliderlabs/ssh from 0.3.3 to 0.3.4 (#429)
  * [2e287c9](https://github.com/tensorchord/envd/commit/2e287c9b1ea4d16c822532e56a39ae67bdf1982c) chore(destroy): add current path `.` as the default path (#422)
  * [750db5a](https://github.com/tensorchord/envd/commit/750db5a20328f5cb10a118ae348b5545dfef5a1f) chore(Makefile): add `help` target (#421)
  * [0c00005](https://github.com/tensorchord/envd/commit/0c0000571b7ffb1a4a9af418b1c91a1c28253ce8) Bootstrap gets error if the envd_buildkitd was stopped before (#417)
@@ -1656,7 +1342,6 @@
  * Kevin Su
  * Yuchen Cheng
  * Zhenzhen Zhao
- * dependabot[bot]
  * kenwoodjw
 
 ## v0.1.0-alpha.12 (2022-06-17)
@@ -1731,10 +1416,6 @@
  * [85123b6](https://github.com/tensorchord/envd/commit/85123b6d427363f595f22ae0410bec6de7a092ef) fix: fix typo (#324)
  * [559e143](https://github.com/tensorchord/envd/commit/559e1435a9585fa32cee3eff73a11a577bcec111) chore(CI): Enable code coverage (#323)
  * [a4cb9dc](https://github.com/tensorchord/envd/commit/a4cb9dc0bf93970d604ac94dd88074f641bcff9b) fix(release): Change docker user (#321)
- * [a5c3427](https://github.com/tensorchord/envd/commit/a5c3427c3feb38dbe5f0d7fdd633a8c978129837) chore(deps): bump github.com/moby/buildkit from 0.10.1 to 0.10.3 (#313)
- * [43ad124](https://github.com/tensorchord/envd/commit/43ad1249ff938277b65bb91d7d8cf6a128380ad3) chore(deps): bump github.com/pkg/sftp from 1.13.4 to 1.13.5 (#309)
- * [5a9c947](https://github.com/tensorchord/envd/commit/5a9c947edf1763745f1523ba7e4f2acf5f476990) chore(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.2 (#310)
- * [4fb34e2](https://github.com/tensorchord/envd/commit/4fb34e29471b0a5625d075af02854f784aceb8a7) chore(deps): bump github.com/urfave/cli/v2 from 2.4.0 to 2.8.1 (#312)
  * [0c63064](https://github.com/tensorchord/envd/commit/0c6306476922f0abcf30771a7d724b150e2188b6) fix: add api/__init__.py (#317)
 
 ### Contributors
@@ -1747,7 +1428,6 @@
  * Yuan Tang
  * Yuchen Cheng
  * Zhizhen He
- * dependabot[bot]
  * kenwoodjw
 
 ## v0.1.0-alpha.6 (2022-06-13)
@@ -1819,10 +1499,6 @@
  * [6e1cf05](https://github.com/tensorchord/envd/commit/6e1cf0509844060040bbd85d4f19e29410fb7a6f) fix: replace useless .editorconfig (#440)
  * [1c23cea](https://github.com/tensorchord/envd/commit/1c23cea84bfb37f2cd5ee0df63bf625448147994) release: Separate alpha and stable release in Homebrew (#439)
  * [274e183](https://github.com/tensorchord/envd/commit/274e18317597bb7a7a6413f59a52e7d5274ac85c) Update PyTorch installation CMD in examples (#435)
- * [cfda1be](https://github.com/tensorchord/envd/commit/cfda1bed6f9861f198d0a37ebc8f46ed4bbb51ab) chore(deps): bump pypa/cibuildwheel from 2.6.1 to 2.7.0 (#428)
- * [d25157e](https://github.com/tensorchord/envd/commit/d25157ef8169f2aa7c7169dfa18b389041a036a0) chore(deps): bump github.com/spf13/viper from 1.4.0 to 1.12.0 (#430)
- * [d394410](https://github.com/tensorchord/envd/commit/d394410331eb25d20a33b6adef68506cbc0b6602) chore(deps): bump goreleaser/goreleaser-action from 2 to 3 (#427)
- * [7070506](https://github.com/tensorchord/envd/commit/7070506f6c2acb44692dd06090ec9d614927ef65) chore(deps): bump github.com/gliderlabs/ssh from 0.3.3 to 0.3.4 (#429)
  * [2e287c9](https://github.com/tensorchord/envd/commit/2e287c9b1ea4d16c822532e56a39ae67bdf1982c) chore(destroy): add current path `.` as the default path (#422)
  * [750db5a](https://github.com/tensorchord/envd/commit/750db5a20328f5cb10a118ae348b5545dfef5a1f) chore(Makefile): add `help` target (#421)
  * [0c00005](https://github.com/tensorchord/envd/commit/0c0000571b7ffb1a4a9af418b1c91a1c28253ce8) Bootstrap gets error if the envd_buildkitd was stopped before (#417)
@@ -1855,10 +1531,6 @@
  * [85123b6](https://github.com/tensorchord/envd/commit/85123b6d427363f595f22ae0410bec6de7a092ef) fix: fix typo (#324)
  * [559e143](https://github.com/tensorchord/envd/commit/559e1435a9585fa32cee3eff73a11a577bcec111) chore(CI): Enable code coverage (#323)
  * [a4cb9dc](https://github.com/tensorchord/envd/commit/a4cb9dc0bf93970d604ac94dd88074f641bcff9b) fix(release): Change docker user (#321)
- * [a5c3427](https://github.com/tensorchord/envd/commit/a5c3427c3feb38dbe5f0d7fdd633a8c978129837) chore(deps): bump github.com/moby/buildkit from 0.10.1 to 0.10.3 (#313)
- * [43ad124](https://github.com/tensorchord/envd/commit/43ad1249ff938277b65bb91d7d8cf6a128380ad3) chore(deps): bump github.com/pkg/sftp from 1.13.4 to 1.13.5 (#309)
- * [5a9c947](https://github.com/tensorchord/envd/commit/5a9c947edf1763745f1523ba7e4f2acf5f476990) chore(deps): bump github.com/stretchr/testify from 1.7.0 to 1.7.2 (#310)
- * [4fb34e2](https://github.com/tensorchord/envd/commit/4fb34e29471b0a5625d075af02854f784aceb8a7) chore(deps): bump github.com/urfave/cli/v2 from 2.4.0 to 2.8.1 (#312)
  * [0c63064](https://github.com/tensorchord/envd/commit/0c6306476922f0abcf30771a7d724b150e2188b6) fix: add api/__init__.py (#317)
  * [12cf334](https://github.com/tensorchord/envd/commit/12cf3345b6c09106508271dd84bd41bc03ceedbc) fix: Fix twine (#301)
  * [f42e162](https://github.com/tensorchord/envd/commit/f42e1625fd11332411b821931d0664494bfc1927) fix: Instal twine (#300)
@@ -1912,7 +1584,6 @@
  * Yuchen Cheng
  * Zhenzhen Zhao
  * Zhizhen He
- * dependabot[bot]
  * kenwoodjw
 
 ## v0.0.1-rc.1 (2022-06-02)

--- a/hack/changelog.sh
+++ b/hack/changelog.sh
@@ -9,7 +9,7 @@ git tag -l 'v*' | sort -rV | while read last; do
   if [ "$tag" != "" ]; then
     echo "## $(git for-each-ref --format='%(refname:strip=2) (%(creatordate:short))' refs/tags/${tag})"
     echo
-    git_log='git --no-pager log --no-merges --invert-grep --grep=^\(build\|ci\|docs\|test\|chore\):'
+    git_log='git --no-pager log --no-merges --invert-grep --grep=^\(build\|ci\|docs\|test\|chore\|chore(deps)\):'
 	  $git_log --format=' * [%h](https://github.com/tensorchord/envd/commit/%H) %s' $last..$tag
 	  echo
 	  echo "### Contributors"


### PR DESCRIPTION
Fixes #1655.