### PR TITLE
chore: fix the goreleaser name template

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,7 +42,8 @@ archives:
     builds:
       - envd
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .Binary }}_
+      {{ .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
@@ -52,7 +53,8 @@ archives:
     builds:
       - envd-sshd
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .Binary }}_
+      {{ .Version }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
- refer to: https://github.com/goreleaser/goreleaser/pull/1838/files
- https://goreleaser.com/customization/archive/

I'm not able to verify it locally since it won't reflect on the local files. It will **ONLY** be used when uploading to GitHub Artifacts.
