### PR TITLE
Fix PATH Order

### DIFF
--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -343,6 +343,7 @@ func (g *generalGraph) compileBaseImage() (llb.State, error) {
 
 	// Set the environment variables to RuntimeEnviron to keep it in the resulting image.
 	logger.Logger.Debugf("inherit envs from base image: %s", config.Env)
+
 	for _, e := range config.Env {
 		// in case the env value also contains `=`
 		kv := strings.SplitN(e, "=", 2)
@@ -353,15 +354,20 @@ func (g *generalGraph) compileBaseImage() (llb.State, error) {
 			// 1. configured paths in the Starlark frontend `runtime.environ(extra_path=[...])`
 			// 2. paths in the base image
 			// 3. others added during the image building (Python paths, etc.)
-			extraPaths := make(map[string]bool)
-			for _, path := range strings.Split(kv[1], ":") {
-				extraPaths[path] = true
-			}
+
+			// iterate over the original paths and add them to the map
+			pathMap := make(map[string]bool)
 			for _, path := range g.RuntimeEnvPaths {
-				extraPaths[path] = false
+				pathMap[path] = true
 			}
-			for path, required := range extraPaths {
-				if required {
+			// split the PATH into different paths
+			newPaths := strings.Split(kv[1], ":")
+			// iterate over the new paths
+			for _, path := range newPaths {
+				// check if the path is already in the map
+				if _, ok := pathMap[path]; !ok {
+					// if not, add the path to the map and slice
+					pathMap[path] = true
 					g.RuntimeEnvPaths = append(g.RuntimeEnvPaths, path)
 				}
 			}

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -343,7 +343,6 @@ func (g *generalGraph) compileBaseImage() (llb.State, error) {
 
 	// Set the environment variables to RuntimeEnviron to keep it in the resulting image.
 	logger.Logger.Debugf("inherit envs from base image: %s", config.Env)
-
 	for _, e := range config.Env {
 		// in case the env value also contains `=`
 		kv := strings.SplitN(e, "=", 2)


### PR DESCRIPTION
Previously, map is unordered, so the new path will have an arbitrary order.

Example Path:
![image](https://github.com/tensorchord/envd/assets/98242479/cccb6d11-00e1-4d32-8b2b-2b95b47166b1)

New Image Path:

- Path With Current Implementation:

![image](https://github.com/tensorchord/envd/assets/98242479/836912db-2e07-4726-9eaa-40a9ba722c34)

- Path With New Changes:

![image](https://github.com/tensorchord/envd/assets/98242479/2d110b19-607a-44bb-a865-ae78023ac001)

By using a map + slice, we can maintain ordering.