### PR TITLE
support using json for registry config

### DIFF
--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -384,6 +384,9 @@ func buildkit(clicontext *cli.Context) error {
 			return errors.Wrap(err, "Failed to parse registry config file")
 		}
 	} else if len(clicontext.String("registry-ca-keypair")) != 0 {
+		// The values of Ca, Cert, and Key don't actually matter since we already copied their contents to the envd config directory and mounted to `/etc/registry`.
+		// So instead of parsing registry-ca-keypair again, we'll just put the default value.
+		// This is to ensure that buildkitConfigTemplate parses properly.
 		config.Registries = append(config.Registries, buildkitutil.Registry{
 			Name:    clicontext.String("registry"),
 			Ca:      "/etc/registry",
@@ -392,9 +395,6 @@ func buildkit(clicontext *cli.Context) error {
 			UseHttp: clicontext.Bool("use-http"),
 			Mirror:  clicontext.String("dockerhub-mirror"),
 		})
-		// The values of Ca, Cert, and Key don't actually matter since we already copied their contents to /etc/registry
-		// So instead of parsing registry-ca-keypair again, we'll just put an arbitrary value
-		// This is to ensure that buildkitConfigTemplate parses properly
 	}
 
 	var bkClient buildkitd.Client

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -207,13 +207,14 @@ func (c dockerClient) StartBuildkitd(ctx context.Context, tag, name string, bc *
 		AutoRemove: true,
 	}
 
-	if len(bc.RegistryName) > 0 {
+	if len(bc.Registries) > 0 {
 		hostConfig.Mounts = append(hostConfig.Mounts, mount.Mount{
 			Type:   mount.TypeBind,
 			Source: fileutil.DefaultConfigDir,
 			Target: buildkitdCertPath,
 		})
 	}
+
 	cfg, err := bc.String()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate buildkit config")

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -207,7 +207,7 @@ func (c dockerClient) StartBuildkitd(ctx context.Context, tag, name string, bc *
 		AutoRemove: true,
 	}
 
-	if bc.SetCA {
+	if len(bc.RegistryName) > 0 {
 		hostConfig.Mounts = append(hostConfig.Mounts, mount.Mount{
 			Type:   mount.TypeBind,
 			Source: fileutil.DefaultConfigDir,

--- a/pkg/driver/nerdctl/nerdctl.go
+++ b/pkg/driver/nerdctl/nerdctl.go
@@ -83,7 +83,7 @@ func (nc *nerdctlClient) StartBuildkitd(ctx context.Context, tag, name string, b
 	if !existed {
 		buildkitdCmd := "buildkitd"
 		// TODO: support mirror CA keypair
-		if len(bc.RegistryName) > 0 || bc.Mirror != "" || len(bc.UseHTTP) > 0 {
+		if len(bc.Registries) > 0 {
 			cfg, err := bc.String()
 			if err != nil {
 				return "", errors.Wrap(err, "failed to generate buildkit config")

--- a/pkg/driver/nerdctl/nerdctl.go
+++ b/pkg/driver/nerdctl/nerdctl.go
@@ -83,7 +83,7 @@ func (nc *nerdctlClient) StartBuildkitd(ctx context.Context, tag, name string, b
 	if !existed {
 		buildkitdCmd := "buildkitd"
 		// TODO: support mirror CA keypair
-		if bc.Registry != "" || bc.Mirror != "" || bc.UseHTTP {
+		if len(bc.RegistryName) > 0 || bc.Mirror != "" || len(bc.UseHTTP) > 0 {
 			cfg, err := bc.String()
 			if err != nil {
 				return "", errors.Wrap(err, "failed to generate buildkit config")

--- a/pkg/util/buildkitutil/buildkit_test.go
+++ b/pkg/util/buildkitutil/buildkit_test.go
@@ -28,12 +28,16 @@ func TestBuildkitWithRegistry(t *testing.T) {
 	}{
 		{
 			BuildkitConfig{
-				RegistryName: []string{"registry.example.com"},
-				CaPath:       []string{"/etc/registry/ca.pem"},
-				CertPath:     []string{"/etc/registry/cert.pem"},
-				KeyPath:      []string{"/etc/registry/key.pem"},
-				UseHTTP:      []bool{false},
-				Mirror:       "https://mirror.example.com",
+				Registries: []Registry{
+					{
+						Name:    "registry.example.com",
+						Ca:      "/etc/registry/ca.pem",
+						Cert:    "/etc/registry/cert.pem",
+						Key:     "/etc/registry/key.pem",
+						UseHttp: false,
+						Mirror:  "https://mirror.example.com",
+					},
+				},
 			},
 			`
 [registry]
@@ -47,12 +51,17 @@ func TestBuildkitWithRegistry(t *testing.T) {
 		},
 		{
 			BuildkitConfig{
-				RegistryName: []string{"registry.example.com", "docker.io"},
-				CaPath:       []string{"", ""},
-				CertPath:     []string{"", ""},
-				KeyPath:      []string{"", ""},
-				UseHTTP:      []bool{true, false},
-				Mirror:       "https://mirror.example.com",
+				Registries: []Registry{
+					{
+						Name:    "registry.example.com",
+						UseHttp: true,
+						Mirror:  "https://mirror.example.com",
+					},
+					{
+						Name:   "docker.io",
+						Mirror: "https://mirror.example.com",
+					},
+				},
 			},
 			`
 [registry]
@@ -65,12 +74,7 @@ func TestBuildkitWithRegistry(t *testing.T) {
 		},
 		{
 			BuildkitConfig{
-				RegistryName: []string{},
-				CaPath:       []string{},
-				CertPath:     []string{},
-				KeyPath:      []string{},
-				UseHTTP:      []bool{},
-				Mirror:       "",
+				Registries: []Registry{},
 			},
 			`
 [registry]
@@ -78,12 +82,23 @@ func TestBuildkitWithRegistry(t *testing.T) {
 		},
 		{
 			BuildkitConfig{
-				RegistryName: []string{"registry1.example.com", "registry2.example.com"},
-				CaPath:       []string{"/etc/registry/ca1.pem", "/etc/registry/ca2.pem"},
-				CertPath:     []string{"/etc/registry/cert1.pem", "/etc/registry/cert2.pem"},
-				KeyPath:      []string{"/etc/registry/key1.pem", "/etc/registry/key2.pem"},
-				UseHTTP:      []bool{true, false},
-				Mirror:       "https://mirror.example.com",
+				Registries: []Registry{
+					{
+						Name:    "registry1.example.com",
+						Ca:      "/etc/registry/ca1.pem",
+						Cert:    "/etc/registry/cert1.pem",
+						Key:     "/etc/registry/key1.pem",
+						UseHttp: true,
+						Mirror:  "https://mirror.example.com",
+					},
+					{
+						Name:   "registry2.example.com",
+						Ca:     "/etc/registry/ca2.pem",
+						Cert:   "/etc/registry/cert2.pem",
+						Key:    "/etc/registry/key2.pem",
+						Mirror: "https://mirror.example.com",
+					},
+				},
 			},
 			`
 [registry]

--- a/pkg/util/buildkitutil/buildkit_test.go
+++ b/pkg/util/buildkitutil/buildkit_test.go
@@ -28,36 +28,79 @@ func TestBuildkitWithRegistry(t *testing.T) {
 	}{
 		{
 			BuildkitConfig{
-				Registry: "registry.example.com",
-				Mirror:   "https://mirror.example.com",
-				UseHTTP:  true,
+				RegistryName: []string{"registry.example.com"},
+				CaPath:       []string{"/etc/registry/ca.pem"},
+				CertPath:     []string{"/etc/registry/cert.pem"},
+				KeyPath:      []string{"/etc/registry/key.pem"},
+				UseHTTP:      []bool{false},
+				Mirror:       "https://mirror.example.com",
 			},
 			`
-[registry."registry.example.com"]
-  mirrors = ["https://mirror.example.com"]
-  http = true
+[registry]
+  [registry."registry.example.com"]
+    mirrors = ["https://mirror.example.com"]
+    ca=["/etc/registry/registry.example.com_ca.pem"]
+    [[registry."registry.example.com".keypair]]
+      key="/etc/registry/registry.example.com_key.pem"
+      cert="/etc/registry/registry.example.com_cert.pem"
 `,
 		},
 		{
 			BuildkitConfig{
-				Registry: "registry.example.com",
-				SetCA:    true,
+				RegistryName: []string{"registry.example.com", "docker.io"},
+				CaPath:       []string{"", ""},
+				CertPath:     []string{"", ""},
+				KeyPath:      []string{"", ""},
+				UseHTTP:      []bool{true, false},
+				Mirror:       "https://mirror.example.com",
 			},
 			`
-[registry."registry.example.com"]
-  http = false
-  ca=["/etc/registry/ca.pem"]
-  [[registry."registry.example.com".keypair]]
-	key="/etc/registry/key.pem"
-	cert="/etc/registry/cert.pem"
+[registry]
+  [registry."registry.example.com"]
+    http = true
+    mirrors = ["https://mirror.example.com"]
+  [registry."docker.io"]
+    mirrors = ["https://mirror.example.com"]
 `,
 		},
 		{
-			BuildkitConfig{},
+			BuildkitConfig{
+				RegistryName: []string{},
+				CaPath:       []string{},
+				CertPath:     []string{},
+				KeyPath:      []string{},
+				UseHTTP:      []bool{},
+				Mirror:       "",
+			},
 			`
-[registry."docker.io"]
-  http = false
-			`,
+[registry]
+`,
+		},
+		{
+			BuildkitConfig{
+				RegistryName: []string{"registry1.example.com", "registry2.example.com"},
+				CaPath:       []string{"/etc/registry/ca1.pem", "/etc/registry/ca2.pem"},
+				CertPath:     []string{"/etc/registry/cert1.pem", "/etc/registry/cert2.pem"},
+				KeyPath:      []string{"/etc/registry/key1.pem", "/etc/registry/key2.pem"},
+				UseHTTP:      []bool{true, false},
+				Mirror:       "https://mirror.example.com",
+			},
+			`
+[registry]
+  [registry."registry1.example.com"]
+    http = true
+    mirrors = ["https://mirror.example.com"]
+    ca=["/etc/registry/registry1.example.com_ca.pem"]
+    [[registry."registry1.example.com".keypair]]
+      key="/etc/registry/registry1.example.com_key.pem"
+      cert="/etc/registry/registry1.example.com_cert.pem"
+  [registry."registry2.example.com"]
+    mirrors = ["https://mirror.example.com"]
+    ca=["/etc/registry/registry2.example.com_ca.pem"]
+    [[registry."registry2.example.com".keypair]]
+      key="/etc/registry/registry2.example.com_key.pem"
+      cert="/etc/registry/registry2.example.com_cert.pem"
+`,
 		},
 	}
 


### PR DESCRIPTION
`envd bootstrap --registry-config path_to_json_file`

Format:
<img width="439" alt="Screenshot 2023-07-03 at 3 03 15 PM" src="https://github.com/tensorchord/envd/assets/98242479/c18425ce-c7b4-4790-8afb-6063718740f9">

Note that the "name" field is required. The other fields are all optional.

This will allow users to specify private Docker registries and the respective credentials. Under the hood, we parse these credentials and create a corresponding buildkit TOML file, as well as set up Docker bindings. This enables users to pull and push images from private Docker registries.

This is also completely backwards compatible with the existing "registry" and "registry-ca-keypair" command. We check that a user only specifies "registy-config" on its own, meaning that a user can't use both registry-config and registry or both registry-config and registry-ca-keypair.

The registry-config command also enables users to specify more than one registry now. For example, if the registry you pull your image from is different than the registry you push your image to, and you need auth for both of them, you should use the registry-config command.