### PR TITLE
docs: fix the cli doc build error

### DIFF
--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -48,12 +48,12 @@ var CommandBootstrap = &cli.Command{
 		},
 		&cli.BoolFlag{
 			Name:  "with-autocomplete",
-			Usage: "Add envd autocompletions",
+			Usage: "Add envd auto-completions",
 			Value: true,
 		},
 		&cli.StringFlag{
 			Name:    "dockerhub-mirror",
-			Usage:   "Dockerhub mirror to use",
+			Usage:   "DockerHub mirror to use",
 			Aliases: []string{"m"},
 		},
 		&cli.StringFlag{
@@ -63,7 +63,7 @@ var CommandBootstrap = &cli.Command{
 		},
 		&cli.StringSliceFlag{
 			Name: "ssh-keypair",
-			Usage: fmt.Sprintf("Manually specify ssh key pair as `publicKey,privateKey`. Envd will generate a keypair at %s and %s if not specified",
+			Usage: fmt.Sprintf("Manually specify ssh key pair as `publicKey,privateKey`. envd will generate a keypair at %s and %s if not specified",
 				sshconfig.GetPublicKeyOrPanic(), sshconfig.GetPrivateKeyOrPanic()),
 			Aliases: []string{"k"},
 		},

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -83,12 +83,12 @@ To build and push the image to a registry:
 		// https://github.com/urfave/cli/issues/1134#issuecomment-1191407527
 		&cli.StringFlag{
 			Name:    "export-cache",
-			Usage:   "Export the cache (e.g. type=registry,ref=<image>)",
+			Usage:   "Export the cache (e.g. `type=registry,ref=<image>`)",
 			Aliases: []string{"ec"},
 		},
 		&cli.StringFlag{
 			Name:    "import-cache",
-			Usage:   "Import the cache (e.g. type=registry,ref=<image>)",
+			Usage:   "Import the cache (e.g. `type=registry,ref=<image>`)",
 			Aliases: []string{"ic"},
 		},
 		&cli.StringFlag{

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -80,7 +80,7 @@ var CommandCreate = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "host",
-			Usage: "Assign the host address for environment ssh acesss server listening",
+			Usage: "Assign the host address for the environment SSH access server listening",
 			Value: envd.Localhost,
 		},
 		&cli.IntFlag{

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -128,18 +128,18 @@ var CommandUp = &cli.Command{
 		},
 		&cli.StringFlag{
 			Name:  "host",
-			Usage: "Assign the host address for environment ssh acesss server listening",
+			Usage: "Assign the host address for the environment SSH access server listening",
 			Value: envd.Localhost,
 		},
 		// https://github.com/urfave/cli/issues/1134#issuecomment-1191407527
 		&cli.StringFlag{
 			Name:    "export-cache",
-			Usage:   "Export the cache (e.g. type=registry,ref=<image>)",
+			Usage:   "Export the cache (e.g. `type=registry,ref=<image>`)",
 			Aliases: []string{"ec"},
 		},
 		&cli.StringFlag{
 			Name:    "import-cache",
-			Usage:   "Import the cache (e.g. type=registry,ref=<image>)",
+			Usage:   "Import the cache (e.g. `type=registry,ref=<image>`)",
 			Aliases: []string{"ic"},
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
The error is caused by `<image>`.

- ref to https://github.com/tensorchord/envd-docs/pull/291 build errors