### PR TITLE
fix(v1): chown the whole envd conda env to user envd

### DIFF
--- a/pkg/lang/ir/v1/conda.go
+++ b/pkg/lang/ir/v1/conda.go
@@ -154,8 +154,7 @@ func (g generalGraph) compileCondaEnvironment(root llb.State) (llb.State, error)
 func (g *generalGraph) installConda(root llb.State) llb.State {
 	if g.Dev {
 		// We only create envd user for dev env.
-		// This directory is related to conda envd env meta (used by `conda env config vars set key=value`)
-		g.UserDirectories = append(g.UserDirectories, fmt.Sprintf("%s/envs/envd/conda-meta", condaRootPrefix))
+		g.UserDirectories = append(g.UserDirectories, fmt.Sprintf("%s/envs/envd", condaRootPrefix))
 	}
 	if g.CondaConfig.UseMicroMamba {
 		return g.installMicroMamba(root)


### PR DESCRIPTION
The whole `envd` env might be used by users when installing new packages.

This can be triggered by `conda install -c conda-forge mosec`.

```
PermissionError: [Errno 13] Permission denied: '/opt/conda/envs/envd/.condatmp'

ERROR conda.core.link:_execute(952): An error occurred while uninstalling package 'defaults/linux-64::openssl-3.0.9-h7f8727e_0'.
Rolling back transaction: done

[Errno 13] Permission denied: '/opt/conda/envs/envd/bin/c_rehash' -> '/opt/conda/envs/envd/bin/c_rehash.c~'

ERROR conda.core.link:_execute(952): An error occurred while uninstalling package 'defaults/linux-64::openssl-3.0.9-h7f8727e_0'.
Rolling back transaction: done

[Errno 13] Permission denied: '/opt/conda/envs/envd/include/openssl/aes.h' -> '/opt/conda/envs/envd/include/openssl/aes.h.c~'
()
```

Previously, we were worried that it might take a long time to recursively chown the whole directory. But I didn't reproduce it now.
