### PR TITLE
chore: pin ci go version to 1.19.10 to avoid the invalid host header

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.19.10
       - name: Cache Go modules
         uses: actions/cache@preview
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -269,7 +269,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.19.10
       - name: Cache Go modules
         uses: actions/cache@preview
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.19.10
       - name: Docker Login
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
- ref https://github.com/golang/go/issues/61431

For now, we only need to pin the version for e2e-cli-v1 test and release.

Will update this after it's fixed.