### PR TITLE
fix: suppress telemetry send err msg

### DIFF
--- a/pkg/app/telemetry/reporter.go
+++ b/pkg/app/telemetry/reporter.go
@@ -149,7 +149,7 @@ func (r *defaultReporter) Identify() {
 			Timestamp: time.Now(),
 			Traits:    segmentio.NewTraits(),
 		}); err != nil {
-			logrus.Warn("telemetry failed")
+			logrus.Debug("telemetry failed")
 			return
 		}
 	}
@@ -176,7 +176,7 @@ func (r *defaultReporter) Telemetry(command string, fields ...TelemetryField) {
 			field(&t.Properties)
 		}
 		if err := r.client.Enqueue(t); err != nil {
-			logrus.Warn(err)
+			logrus.Debug(err)
 		}
 		// make sure the msg can be sent out
 		r.client.Close()


### PR DESCRIPTION
It might fail due to the segmentio free plan limit (1,000 visitors/mo).