### PR TITLE
fix: prune bin from py source dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,9 +2,14 @@ include LICENSE
 include README.md
 include Makefile
 include .goreleaser.yaml .goreleaser/*.Dockerfile
-include pkg/* cmd/*
 include go.mod go.sum
 include .GIT_TAG_INFO
+graft pkg
+graft cmd
 prune examples
+prune bin
+prune hack
+prune e2e
+prune dist
 prune docs
 prune .github


### PR DESCRIPTION
https://pypi.org/project/envd/#files  this source dist also contains an `envd` binary.