### PR TITLE
feat: add envd app exit handler

### DIFF
--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -155,6 +155,12 @@ func New() EnvdApp {
 		return nil
 	}
 
+	internalApp.ExitErrHandler = func(context *cli.Context, err error) {
+		if err != nil {
+			logrus.Fatal(err)
+		}
+	}
+
 	return EnvdApp{
 		App: *internalApp,
 	}

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -96,7 +96,12 @@ func NormalizeName(s string) (string, error) {
 	}
 	// remove the spaces
 	s = strings.ReplaceAll(s, " ", "")
-	return s, nil
+	name, err := reference.ParseDockerRef(s)
+	if err != nil {
+		// return "", errors.Newf("failed to parse the name %s, please provide another valid name", s)
+		return "", errors.Wrapf(err, "failed to parse the name '%s'", s)
+	}
+	return name.String(), nil
 }
 
 func (c dockerClient) ListImage(ctx context.Context) ([]types.ImageSummary, error) {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -96,7 +96,7 @@ func NormalizeName(s string) (string, error) {
 	}
 	// remove the spaces
 	s = strings.ReplaceAll(s, " ", "")
-	name, err := reference.ParseDockerRef(s)
+	name, err := reference.Parse(s)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to parse the name '%s', please provide a valid image name", s)
 	}

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -98,8 +98,7 @@ func NormalizeName(s string) (string, error) {
 	s = strings.ReplaceAll(s, " ", "")
 	name, err := reference.ParseDockerRef(s)
 	if err != nil {
-		// return "", errors.Newf("failed to parse the name %s, please provide another valid name", s)
-		return "", errors.Wrapf(err, "failed to parse the name '%s'", s)
+		return "", errors.Wrapf(err, "failed to parse the name '%s', please provide a valid image name", s)
 	}
 	return name.String(), nil
 }


### PR DESCRIPTION
- close #1719 

I just found that the default `urfave/cli` error handler cannot print the full error backtrace messages.

Before:
```sh
error: invalid reference format
```

After:
```sh
FATA[2023-08-04T16:25:13+08:00] failed to parse the build options: failed to parse the name '_dir:dev', please provide a valid image name: invalid reference format
```