### PR TITLE
feat: inherit the workdir from base image for non-dev env

### DIFF
--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -198,8 +198,9 @@ func (b generalBuilder) imageConfig(ctx context.Context) (string, error) {
 	env := b.graph.GetEnviron()
 	user := b.graph.GetUser()
 	platform := b.graph.GetPlatform()
+	workingDir := b.graph.GetWorkingDir()
 
-	data, err := ImageConfigStr(labels, ports, ep, env, user, platform)
+	data, err := ImageConfigStr(labels, ports, ep, env, user, workingDir, platform)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get image config")
 	}

--- a/pkg/builder/util.go
+++ b/pkg/builder/util.go
@@ -35,12 +35,12 @@ const (
 )
 
 func ImageConfigStr(labels map[string]string, ports map[string]struct{},
-	entrypoint []string, env []string, user string, platform *ocispecs.Platform) (string, error) {
+	entrypoint []string, env []string, user, workingDir string, platform *ocispecs.Platform) (string, error) {
 	img := ocispecs.Image{
 		Config: ocispecs.ImageConfig{
 			Labels:       labels,
 			User:         user,
-			WorkingDir:   "/",
+			WorkingDir:   workingDir,
 			Env:          env,
 			ExposedPorts: ports,
 			Entrypoint:   entrypoint,

--- a/pkg/lang/ir/graph.go
+++ b/pkg/lang/ir/graph.go
@@ -58,4 +58,5 @@ type graphVisitor interface {
 	GetRuntimeCommands() map[string]string
 	GetUser() string
 	GetPlatform() *ocispecs.Platform
+	GetWorkingDir() string
 }

--- a/pkg/lang/ir/v0/compile.go
+++ b/pkg/lang/ir/v0/compile.go
@@ -67,6 +67,7 @@ func NewGraph() ir.Graph {
 		CondaConfig:     conda,
 		RuntimeGraph:    runtimeGraph,
 		Platform:        &ocispecs.Platform{},
+		WorkingDir:      "/",
 	}
 }
 
@@ -110,6 +111,10 @@ func (g generalGraph) GetUser() string {
 
 func (g generalGraph) GetPlatform() *ocispecs.Platform {
 	return g.Platform
+}
+
+func (g generalGraph) GetWorkingDir() string {
+	return g.WorkingDir
 }
 
 func (g *generalGraph) Compile(ctx context.Context, envPath string, pub string, platform *ocispecs.Platform, progressMode string) (*llb.Definition, error) {

--- a/pkg/lang/ir/v0/system.go
+++ b/pkg/lang/ir/v0/system.go
@@ -224,6 +224,8 @@ func (g *generalGraph) compileBase() (llb.State, error) {
 		base = g.compileCUDAPackages("nvidia/cuda")
 	}
 
+	g.WorkingDir = g.getWorkingDir()
+
 	// Install conda first.
 	condaStage := g.installConda(base)
 	supervisor := g.installHorust(condaStage)

--- a/pkg/lang/ir/v0/types.go
+++ b/pkg/lang/ir/v0/types.go
@@ -79,6 +79,9 @@ type generalGraph struct {
 	EnvironmentName string
 	// EnvironmentPath is the full path of this environment.
 	EnvironmentPath string
+	// WorkingDir is the working directory of this environment.
+	// This only affect the `WorkingDir` in the image config.
+	WorkingDir string
 
 	ir.RuntimeGraph
 

--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -60,6 +60,7 @@ func NewGraph() ir.Graph {
 		Shell:           shellBASH,
 		RuntimeGraph:    runtimeGraph,
 		Platform:        &ocispecs.Platform{},
+		WorkingDir:      "/",
 	}
 }
 
@@ -107,6 +108,10 @@ func (g generalGraph) GetRuntimeCommands() map[string]string {
 
 func (g generalGraph) GetPlatform() *ocispecs.Platform {
 	return g.Platform
+}
+
+func (g generalGraph) GetWorkingDir() string {
+	return g.WorkingDir
 }
 
 func (g *generalGraph) Compile(ctx context.Context, envPath string, pub string, platform *ocispecs.Platform, progressMode string) (*llb.Definition, error) {

--- a/pkg/lang/ir/v1/python.go
+++ b/pkg/lang/ir/v1/python.go
@@ -131,7 +131,6 @@ func (g generalGraph) compilePyPIPackages(root llb.State) llb.State {
 	if g.RequirementsFile != nil {
 		logrus.WithField("file", *g.RequirementsFile).
 			Debug("Configure pip install requirements statements")
-		root = root.Dir(g.getWorkingDir())
 		dependencies, safeToCopy := g.IsRequirementsFileSafeToCopyContent()
 		logrus.WithField("safeToCopy", safeToCopy).WithField("dependencies", dependencies).
 			Debug("Is requirements file safe to copy")
@@ -143,7 +142,7 @@ func (g generalGraph) compilePyPIPackages(root llb.State) llb.State {
 				llb.WithCustomNamef("[internal] pip install from %s with %s", *g.RequirementsFile, strings.Join(dependencies, " ")),
 			).Root()
 		} else {
-			run := root.
+			run := root.Dir(g.getWorkingDir()).
 				Run(llb.Shlexf("python -m pip install -r %s", *g.RequirementsFile),
 					llb.WithCustomNamef("[internal] pip install -r %s", *g.RequirementsFile))
 			run.AddMount(cacheDir, cache,

--- a/pkg/lang/ir/v1/system.go
+++ b/pkg/lang/ir/v1/system.go
@@ -252,6 +252,22 @@ func (g *generalGraph) compileLanguage(root llb.State) (llb.State, error) {
 	langs := []llb.State{}
 	lang := root
 	var err error
+
+	if g.DisableMergeOp {
+		for _, language := range g.Languages {
+			switch language.Name {
+			case "python":
+				root, err = g.installPython(root)
+			case "r":
+				rSrc := g.compileRLang(root)
+				root = g.installRLang(rSrc)
+			case "julia":
+				root = g.installJulia(root)
+			}
+		}
+		return root, err
+	}
+
 	for _, language := range g.Languages {
 		switch language.Name {
 		case "python":
@@ -396,9 +412,11 @@ func (g *generalGraph) compileBaseImage() (llb.State, error) {
 			g.Entrypoint = config.Entrypoint
 		}
 		g.User = config.User
+		g.WorkingDir = config.WorkingDir
 	} else {
 		// for dev mode, we will create an `envd` user
 		g.User = ""
+		g.WorkingDir = g.getWorkingDir()
 	}
 	return base, nil
 }

--- a/pkg/lang/ir/v1/types.go
+++ b/pkg/lang/ir/v1/types.go
@@ -80,6 +80,9 @@ type generalGraph struct {
 	EnvironmentName string
 	// EnvironmentPath is the full path of this environment.
 	EnvironmentPath string
+	// WorkingDir is the working directory of this environment.
+	// This only affect the `WorkingDir` in the image config.
+	WorkingDir string
 
 	// (v1) disable `merge` op for `moby` builder
 	// check https://github.com/tensorchord/envd/issues/1693


### PR DESCRIPTION
This only affects the `WorkingDir` in the image config.

`envd up` will override this (though the `dev` image's default `WorkingDir` is already changed from `/` to `/home/envd/<env_name>` in this PR).

cc @gaocegege @RichhLi 