### PR TITLE
feat: abort when trying to run `envd up` on non-dev images

### DIFF
--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -195,6 +195,9 @@ func up(clicontext *cli.Context) error {
 	if err = buildutil.InterpretEnvdDef(builder); err != nil {
 		return err
 	}
+	if !builder.GetGraph().IsDev() {
+		return errors.New("`envd up` only works for dev images. If you're using v1, please enable dev with `base(dev=True)`.")
+	}
 	if err = buildutil.DetectEnvironment(clicontext, buildOpt); err != nil {
 		return err
 	}

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -125,6 +125,10 @@ func (b generalBuilder) ShmSize() int {
 	return b.graph.GetShmSize()
 }
 
+func (b generalBuilder) IsDev() bool {
+	return b.graph.IsDev()
+}
+
 func (b generalBuilder) Build(ctx context.Context, force bool) error {
 	if !force && !b.checkIfNeedBuild(ctx) {
 		return nil

--- a/pkg/lang/ir/graph.go
+++ b/pkg/lang/ir/graph.go
@@ -44,6 +44,7 @@ type graphVisitor interface {
 	GPUEnabled() bool
 	GetNumGPUs() int
 	GetShmSize() int
+	IsDev() bool
 	Labels() (map[string]string, error)
 	ExposedPorts() (map[string]struct{}, error)
 	GetEntrypoint(buildContextDir string) ([]string, error)

--- a/pkg/lang/ir/v0/compile.go
+++ b/pkg/lang/ir/v0/compile.go
@@ -74,6 +74,10 @@ func NewGraph() ir.Graph {
 
 var DefaultGraph = NewGraph()
 
+func (g generalGraph) IsDev() bool {
+	return g.Image != nil
+}
+
 func (g generalGraph) GetShmSize() int {
 	return g.ShmSize
 }

--- a/pkg/lang/ir/v0/compile.go
+++ b/pkg/lang/ir/v0/compile.go
@@ -75,7 +75,7 @@ func NewGraph() ir.Graph {
 var DefaultGraph = NewGraph()
 
 func (g generalGraph) IsDev() bool {
-	return g.Image != nil
+	return g.Image == nil
 }
 
 func (g generalGraph) GetShmSize() int {

--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -71,6 +71,10 @@ func (g *generalGraph) SetWriter(w compileui.Writer) {
 	g.Writer = w
 }
 
+func (g generalGraph) IsDev() bool {
+	return g.Dev
+}
+
 func (g generalGraph) GetHTTP() []ir.HTTPInfo {
 	return g.HTTP
 }


### PR DESCRIPTION
Before this PR, the error message is:

```console
failed to start the envd environment: failed to create the container: Error response from daemon: No command specified
```

After this PR:

```console
FATA[2023-09-01T14:31:23+08:00] `envd up` only works for dev images. If you're using v1, please enable dev with `base(dev=True)`.
```