### PR TITLE
feat(log): switch to structured logging(#issue 889)

### DIFF
--- a/cmd/envd-sshd/main.go
+++ b/cmd/envd-sshd/main.go
@@ -103,7 +103,7 @@ func main() {
 func sshServer(c *cli.Context) error {
 	err := sshd.GetShell(c.String(flagShell))
 	if err != nil {
-		logrus.Fatal(err.Error())
+		logrus.WithError(err).Fatal()
 	}
 	shell := c.String(flagShell)
 

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -159,8 +159,8 @@ func New() EnvdApp {
 	internalApp.ExitErrHandler = func(context *cli.Context, err error) {
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
-				"app": 		"envd",
-				"version": 	internalApp.Version,
+				"app":     "envd",
+				"version": internalApp.Version,
 			}).WithError(err).Fatal("exit")
 		}
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -159,8 +159,8 @@ func New() EnvdApp {
 	internalApp.ExitErrHandler = func(context *cli.Context, err error) {
 		if err != nil {
 			logrus.WithFields(logrus.Fields{
-				"app": "envd",
-				"version": internalApp.Version,
+				"app": 		"envd",
+				"version": 	internalApp.Version,
 			}).WithError(err).Fatal("exit")
 		}
 	}

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -158,7 +158,10 @@ func New() EnvdApp {
 
 	internalApp.ExitErrHandler = func(context *cli.Context, err error) {
 		if err != nil {
-			logrus.Fatal(err)
+			logrus.WithFields(logrus.Fields{
+				"app": "envd",
+				"version": internalApp.Version,
+			}).WithError(err).Fatal("exit")
 		}
 	}
 

--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -363,13 +363,13 @@ func autocomplete(clicontext *cli.Context) error {
 			logger.WithError(err).Warn()
 		}
 	} else {
-		logger.Infof("Install bash autocompletion (fallback from \"%s\")", shell)
+		logger.Infof(`Install bash autocompletion (fallback from "%s")`, shell)
 		if err := ac.InsertBashCompleteEntry(clicontext); err != nil {
 			logger.WithError(err).Warn()
 		}
 	}
 
-	logger.Info("You may have to restart your shell for autocomplete to get initialized (e.g. run \"exec $SHELL\")\n")
+	logger.Info(`You may have to restart your shell for autocomplete to get initialized (e.g. run "exec $SHELL")\n`)
 	return nil
 }
 

--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -252,12 +252,6 @@ func registryJSONConfig(clicontext *cli.Context) error {
 func sshKey(clicontext *cli.Context) error {
 	sshKeyPair := clicontext.StringSlice("ssh-keypair")
 
-	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "bootstrap",
-		"stage": "sshKey",
-		"sshKeyPair": sshKeyPair,
-	})
-
 	switch len(sshKeyPair) {
 	case 0:
 		// If not specified, generate only if key doesn't exist
@@ -297,7 +291,13 @@ func sshKey(clicontext *cli.Context) error {
 					return err
 				}
 			}
-			logger.Debugf("New key name: %s", newPrivateKeyName)
+
+			logrus.WithFields(logrus.Fields{
+				"cmd": 			"bootstrap",
+				"stage": 		"sshKey",
+				"sshKeyPair": 	sshKeyPair,
+			}).Debugf("New key name: %s", newPrivateKeyName)
+			
 			if err := sshconfig.ReplaceKeyManagedByEnvd(
 				privatePath, newPrivateKeyName); err != nil {
 				return err
@@ -342,9 +342,9 @@ func autocomplete(clicontext *cli.Context) error {
 	shell := os.Getenv("SHELL")
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "bootstrap",
-		"stage": "autocomplete",
-		"shell": shell,
+		"cmd": 		"bootstrap",
+		"stage": 	"autocomplete",
+		"shell": 	shell,
 	})
 
 	if strings.Contains(shell, "zsh") {
@@ -385,8 +385,8 @@ func buildkit(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "bootstrap",
-		"stage": "buildkit",
+		"cmd": 		"bootstrap",
+		"stage": 	"buildkit",
 	})
 
 	logger.Debug("bootstrap the buildkitd container")

--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -350,22 +350,22 @@ func autocomplete(clicontext *cli.Context) error {
 	if strings.Contains(shell, "zsh") {
 		logger.Infof("Install zsh autocompletion")
 		if err := ac.InsertZSHCompleteEntry(clicontext); err != nil {
-			logger.Warnf("Warning: %s\n", err.Error())
+			logger.WithError(err).Warn()
 		}
 	} else if strings.Contains(shell, "bash") {
 		logger.Infof("Install bash autocompletion")
 		if err := ac.InsertBashCompleteEntry(clicontext); err != nil {
-			logger.Warnf("Warning: %s\n", err.Error())
+			logger.WithError(err).Warn()
 		}
 	} else if strings.Contains(shell, "fish") {
 		logger.Infof("Install fish autocompletion")
 		if err := ac.InsertFishCompleteEntry(clicontext); err != nil {
-			logger.Warnf("Warning: %s\n", err.Error())
+			logger.WithError(err).Warn()
 		}
 	} else {
 		logger.Infof("Install bash autocompletion (fallback from \"%s\")", shell)
 		if err := ac.InsertBashCompleteEntry(clicontext); err != nil {
-			logger.Warnf("Warning: %s\n", err.Error())
+			logger.WithError(err).Warn()
 		}
 	}
 

--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -293,11 +293,11 @@ func sshKey(clicontext *cli.Context) error {
 			}
 
 			logrus.WithFields(logrus.Fields{
-				"cmd": 			"bootstrap",
-				"stage": 		"sshKey",
-				"sshKeyPair": 	sshKeyPair,
+				"cmd":        "bootstrap",
+				"stage":      "sshKey",
+				"sshKeyPair": sshKeyPair,
 			}).Debugf("New key name: %s", newPrivateKeyName)
-			
+
 			if err := sshconfig.ReplaceKeyManagedByEnvd(
 				privatePath, newPrivateKeyName); err != nil {
 				return err
@@ -342,9 +342,9 @@ func autocomplete(clicontext *cli.Context) error {
 	shell := os.Getenv("SHELL")
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 		"bootstrap",
-		"stage": 	"autocomplete",
-		"shell": 	shell,
+		"cmd":   "bootstrap",
+		"stage": "autocomplete",
+		"shell": shell,
 	})
 
 	if strings.Contains(shell, "zsh") {
@@ -385,8 +385,8 @@ func buildkit(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 		"bootstrap",
-		"stage": 	"buildkit",
+		"cmd":   "bootstrap",
+		"stage": "buildkit",
 	})
 
 	logger.Debug("bootstrap the buildkitd container")

--- a/pkg/app/bootstrap.go
+++ b/pkg/app/bootstrap.go
@@ -110,7 +110,8 @@ func bootstrap(clicontext *cli.Context) error {
 
 	total := len(stages)
 	for i, stage := range stages {
-		logrus.Infof("[%d/%d] Bootstrap %s", i+1, total, stage.Name)
+		logrus.WithField("cmd", "bootstrap").
+			Infof("[%d/%d] Bootstrap %s", i+1, total, stage.Name)
 		err := stage.Func(clicontext)
 		if err != nil {
 			return err
@@ -251,6 +252,12 @@ func registryJSONConfig(clicontext *cli.Context) error {
 func sshKey(clicontext *cli.Context) error {
 	sshKeyPair := clicontext.StringSlice("ssh-keypair")
 
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "bootstrap",
+		"stage": "sshKey",
+		"sshKeyPair": sshKeyPair,
+	})
+
 	switch len(sshKeyPair) {
 	case 0:
 		// If not specified, generate only if key doesn't exist
@@ -290,7 +297,7 @@ func sshKey(clicontext *cli.Context) error {
 					return err
 				}
 			}
-			logrus.Debugf("New key name: %s", newPrivateKeyName)
+			logger.Debugf("New key name: %s", newPrivateKeyName)
 			if err := sshconfig.ReplaceKeyManagedByEnvd(
 				privatePath, newPrivateKeyName); err != nil {
 				return err
@@ -333,29 +340,36 @@ func autocomplete(clicontext *cli.Context) error {
 	}
 
 	shell := os.Getenv("SHELL")
+
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "bootstrap",
+		"stage": "autocomplete",
+		"shell": shell,
+	})
+
 	if strings.Contains(shell, "zsh") {
-		logrus.Infof("Install zsh autocompletion")
+		logger.Infof("Install zsh autocompletion")
 		if err := ac.InsertZSHCompleteEntry(clicontext); err != nil {
-			logrus.Warnf("Warning: %s\n", err.Error())
+			logger.Warnf("Warning: %s\n", err.Error())
 		}
 	} else if strings.Contains(shell, "bash") {
-		logrus.Infof("Install bash autocompletion")
+		logger.Infof("Install bash autocompletion")
 		if err := ac.InsertBashCompleteEntry(clicontext); err != nil {
-			logrus.Warnf("Warning: %s\n", err.Error())
+			logger.Warnf("Warning: %s\n", err.Error())
 		}
 	} else if strings.Contains(shell, "fish") {
-		logrus.Infof("Install fish autocompletion")
+		logger.Infof("Install fish autocompletion")
 		if err := ac.InsertFishCompleteEntry(clicontext); err != nil {
-			logrus.Warnf("Warning: %s\n", err.Error())
+			logger.Warnf("Warning: %s\n", err.Error())
 		}
 	} else {
-		logrus.Infof("Install bash autocompletion (fallback from \"%s\")", shell)
+		logger.Infof("Install bash autocompletion (fallback from \"%s\")", shell)
 		if err := ac.InsertBashCompleteEntry(clicontext); err != nil {
-			logrus.Warnf("Warning: %s\n", err.Error())
+			logger.Warnf("Warning: %s\n", err.Error())
 		}
 	}
 
-	logrus.Info("You may have to restart your shell for autocomplete to get initialized (e.g. run \"exec $SHELL\")\n")
+	logger.Info("You may have to restart your shell for autocomplete to get initialized (e.g. run \"exec $SHELL\")\n")
 	return nil
 }
 
@@ -370,7 +384,12 @@ func buildkit(clicontext *cli.Context) error {
 		return errors.Wrap(err, "failed to get the current context")
 	}
 
-	logrus.Debug("bootstrap the buildkitd container")
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "bootstrap",
+		"stage": "buildkit",
+	})
+
+	logger.Debug("bootstrap the buildkitd container")
 	// Populate the BuildkitConfig struct
 	config := buildkitutil.BuildkitConfig{}
 
@@ -418,7 +437,7 @@ func buildkit(clicontext *cli.Context) error {
 		}
 	}
 	defer bkClient.Close()
-	logrus.Infof("The buildkit is running at %s", bkClient.BuildkitdAddr())
+	logger.Infof("The buildkit is running at %s", bkClient.BuildkitdAddr())
 
 	return nil
 }

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -112,8 +112,8 @@ func build(clicontext *cli.Context) error {
 	}(time.Now())
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "build",
-		"builder-options": opt,
+		"cmd": 				"build",
+		"builder-options": 	opt,
 	})
 	logger.Debug("starting build command")
 

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -112,8 +112,8 @@ func build(clicontext *cli.Context) error {
 	}(time.Now())
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 				"build",
-		"builder-options": 	opt,
+		"cmd":             "build",
+		"builder-options": opt,
 	})
 	logger.Debug("starting build command")
 

--- a/pkg/app/build.go
+++ b/pkg/app/build.go
@@ -111,7 +111,10 @@ func build(clicontext *cli.Context) error {
 			"build", telemetry.AddField("duration", time.Since(start).Seconds()))
 	}(time.Now())
 
-	logger := logrus.WithField("builder-options", opt)
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "build",
+		"builder-options": opt,
+	})
 	logger.Debug("starting build command")
 
 	platforms := strings.Split(opt.Platform, ",")

--- a/pkg/app/completion.go
+++ b/pkg/app/completion.go
@@ -75,7 +75,8 @@ func completion(clicontext *cli.Context) error {
 	}
 
 	for i := 0; i < n; i++ {
-		logrus.WithField("cmd", "completion").Infof("[%d/%d] Add completion %s", i+1, n, shellList[i])
+		logrus.WithField("cmd", "completion").
+			Infof("[%d/%d] Add completion %s", i+1, n, shellList[i])
 		switch shellList[i] {
 		case "zsh":
 			if err := handleCompletion(clicontext, ac.InsertZSHCompleteEntry, ac.ZshCompleteEntry); err != nil {

--- a/pkg/app/completion.go
+++ b/pkg/app/completion.go
@@ -75,7 +75,7 @@ func completion(clicontext *cli.Context) error {
 	}
 
 	for i := 0; i < n; i++ {
-		logrus.Infof("[%d/%d] Add completion %s", i+1, n, shellList[i])
+		logrus.WithField("cmd", "completion").Infof("[%d/%d] Add completion %s", i+1, n, shellList[i])
 		switch shellList[i] {
 		case "zsh":
 			if err := handleCompletion(clicontext, ac.InsertZSHCompleteEntry, ac.ZshCompleteEntry); err != nil {

--- a/pkg/app/context_create.go
+++ b/pkg/app/context_create.go
@@ -69,13 +69,13 @@ func contextCreate(clicontext *cli.Context) error {
 	use := clicontext.Bool("use")
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "context use",
-		"name": name,
-		"builder": builder,
-		"builderAddress": builderAddress,
-		"runner": runner,
-		"runnerAddress": runnerAddress,
-		"use": use,
+		"cmd": 				"context use",
+		"name": 			name,
+		"builder": 			builder,
+		"builderAddress": 	builderAddress,
+		"runner": 			runner,
+		"runnerAddress": 	runnerAddress,
+		"use": 				use,
 	})
 
 	c := types.Context{

--- a/pkg/app/context_create.go
+++ b/pkg/app/context_create.go
@@ -69,7 +69,7 @@ func contextCreate(clicontext *cli.Context) error {
 	use := clicontext.Bool("use")
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd":            "context use",
+		"cmd":            "context create",
 		"name":           name,
 		"builder":        builder,
 		"builderAddress": builderAddress,
@@ -94,7 +94,7 @@ func contextCreate(clicontext *cli.Context) error {
 	}
 	logger.Infof("Context %s is created", name)
 	if use {
-		logger.Infof("Current context is now \"%s\"", name)
+		logger.Infof(`Current context is "%s"`, name)
 	}
 	return nil
 }

--- a/pkg/app/context_create.go
+++ b/pkg/app/context_create.go
@@ -69,13 +69,13 @@ func contextCreate(clicontext *cli.Context) error {
 	use := clicontext.Bool("use")
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 				"context use",
-		"name": 			name,
-		"builder": 			builder,
-		"builderAddress": 	builderAddress,
-		"runner": 			runner,
-		"runnerAddress": 	runnerAddress,
-		"use": 				use,
+		"cmd":            "context use",
+		"name":           name,
+		"builder":        builder,
+		"builderAddress": builderAddress,
+		"runner":         runner,
+		"runnerAddress":  runnerAddress,
+		"use":            use,
 	})
 
 	c := types.Context{

--- a/pkg/app/context_create.go
+++ b/pkg/app/context_create.go
@@ -68,6 +68,16 @@ func contextCreate(clicontext *cli.Context) error {
 	runnerAddress := clicontext.String("runner-address")
 	use := clicontext.Bool("use")
 
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "context use",
+		"name": name,
+		"builder": builder,
+		"builderAddress": builderAddress,
+		"runner": runner,
+		"runnerAddress": runnerAddress,
+		"use": use,
+	})
+
 	c := types.Context{
 		Name:           name,
 		Builder:        types.BuilderType(builder),
@@ -82,9 +92,9 @@ func contextCreate(clicontext *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create context")
 	}
-	logrus.Infof("Context %s is created", name)
+	logger.Infof("Context %s is created", name)
 	if use {
-		logrus.Infof("Current context is now \"%s\"", name)
+		logger.Infof("Current context is now \"%s\"", name)
 	}
 	return nil
 }

--- a/pkg/app/context_rm.go
+++ b/pkg/app/context_rm.go
@@ -43,6 +43,7 @@ func contextRemove(clicontext *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to remove context")
 	}
-	logrus.Infof("Context %s is removed", name)
+	logrus.WithField("cmd", "context remove").
+		Infof("Context %s is removed", name)
 	return nil
 }

--- a/pkg/app/context_use.go
+++ b/pkg/app/context_use.go
@@ -44,6 +44,6 @@ func contextUse(clicontext *cli.Context) error {
 		return errors.Wrapf(err, "failed to use the specified context %s", name)
 	}
 	logrus.WithField("cmd", "context use").
-		Infof("Current context is now \"%s\"", name)
+		Infof(`Current context is "%s"`, name)
 	return nil
 }

--- a/pkg/app/context_use.go
+++ b/pkg/app/context_use.go
@@ -43,6 +43,7 @@ func contextUse(clicontext *cli.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to use the specified context %s", name)
 	}
-	logrus.Infof("Current context is now \"%s\"", name)
+	logrus.WithField("cmd", "context use").
+		Infof("Current context is now \"%s\"", name)
 	return nil
 }

--- a/pkg/app/debug_llb.go
+++ b/pkg/app/debug_llb.go
@@ -77,6 +77,7 @@ func debugLLB(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
+		"cmd": 			 "debug llb",
 		"build-context": opt.BuildContextDir,
 		"build-file":    opt.ManifestFilePath,
 		"config":        opt.ConfigFilePath,

--- a/pkg/app/debug_llb.go
+++ b/pkg/app/debug_llb.go
@@ -77,7 +77,7 @@ func debugLLB(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 			 "debug llb",
+		"cmd":           "debug llb",
 		"build-context": opt.BuildContextDir,
 		"build-file":    opt.ManifestFilePath,
 		"config":        opt.ConfigFilePath,

--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -82,6 +82,12 @@ func destroy(clicontext *cli.Context) error {
 		return errors.New("Cannot specify --path and --name at the same time.")
 	}
 
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "destroy",
+		"path": path,
+		"name": name,
+	})
+
 	var ctrName string
 	if name != "" {
 		ctrName = name
@@ -127,11 +133,11 @@ func destroy(clicontext *cli.Context) error {
 	if ctrName, err := envdEngine.Destroy(clicontext.Context, ctrName); err != nil {
 		return errors.Wrapf(err, "failed to destroy the environment: %s", ctrName)
 	} else if ctrName != "" {
-		logrus.Infof("environment(%s) is destroyed", ctrName)
+		logger.Infof("environment(%s) is destroyed", ctrName)
 	}
 
 	if err = sshconfig.RemoveEntry(ctrName); err != nil {
-		logrus.Infof("failed to remove entry %s from your SSH config file: %s", ctrName, err)
+		logger.Infof("failed to remove entry %s from your SSH config file: %s", ctrName, err)
 		return errors.Wrap(err, "failed to remove entry from your SSH config file")
 	}
 

--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -137,7 +137,8 @@ func destroy(clicontext *cli.Context) error {
 	}
 
 	if err = sshconfig.RemoveEntry(ctrName); err != nil {
-		logger.Infof("failed to remove entry %s from your SSH config file: %s", ctrName, err)
+		logger.WithError(err).
+			Infof("failed to remove entry %s from your SSH config file", ctrName)
 		return errors.Wrap(err, "failed to remove entry from your SSH config file")
 	}
 

--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -83,7 +83,7 @@ func destroy(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "destroy",
+		"cmd": 	"destroy",
 		"path": path,
 		"name": name,
 	})

--- a/pkg/app/destroy.go
+++ b/pkg/app/destroy.go
@@ -83,7 +83,7 @@ func destroy(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 	"destroy",
+		"cmd":  "destroy",
 		"path": path,
 		"name": name,
 	})

--- a/pkg/app/exec.go
+++ b/pkg/app/exec.go
@@ -111,7 +111,14 @@ func exec(clicontext *cli.Context) error {
 			return errors.Wrapf(err, "failed to get environment: %s", name)
 		}
 
-		logrus.Debugf("runtime commands: %s", rg.RuntimeCommands)
+		logrus.WithFields(logrus.Fields{
+			"cmd": "exec",
+			"name": name,
+			"command": command,
+			"rawCommand": rawCommand,
+			"path": path,
+		}).Debugf("runtime commands: %s", rg.RuntimeCommands)
+		
 		cmd, ok := rg.RuntimeCommands[command]
 		if !ok {
 			return errors.Newf("command %s does not exist", command)

--- a/pkg/app/exec.go
+++ b/pkg/app/exec.go
@@ -112,11 +112,11 @@ func exec(clicontext *cli.Context) error {
 		}
 
 		logrus.WithFields(logrus.Fields{
-			"cmd": "exec",
-			"name": name,
-			"command": command,
-			"rawCommand": rawCommand,
-			"path": path,
+			"cmd": 			"exec",
+			"name": 		name,
+			"command": 		command,
+			"rawCommand": 	rawCommand,
+			"path": 		path,
 		}).Debugf("runtime commands: %s", rg.RuntimeCommands)
 		
 		cmd, ok := rg.RuntimeCommands[command]

--- a/pkg/app/exec.go
+++ b/pkg/app/exec.go
@@ -112,13 +112,13 @@ func exec(clicontext *cli.Context) error {
 		}
 
 		logrus.WithFields(logrus.Fields{
-			"cmd": 			"exec",
-			"name": 		name,
-			"command": 		command,
-			"rawCommand": 	rawCommand,
-			"path": 		path,
+			"cmd":        "exec",
+			"name":       name,
+			"command":    command,
+			"rawCommand": rawCommand,
+			"path":       path,
 		}).Debugf("runtime commands: %s", rg.RuntimeCommands)
-		
+
 		cmd, ok := rg.RuntimeCommands[command]
 		if !ok {
 			return errors.Newf("command %s does not exist", command)

--- a/pkg/app/image_remove.go
+++ b/pkg/app/image_remove.go
@@ -49,9 +49,9 @@ func removeImage(clicontext *cli.Context) error {
 	tag := clicontext.String("tag")
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 			"images remove",
-		"imageName": 	imageName,
-		"tag": 			tag,
+		"cmd":       "images remove",
+		"imageName": imageName,
+		"tag":       tag,
 	})
 
 	if imageName == "" {

--- a/pkg/app/image_remove.go
+++ b/pkg/app/image_remove.go
@@ -49,9 +49,9 @@ func removeImage(clicontext *cli.Context) error {
 	tag := clicontext.String("tag")
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "images remove",
-		"imageName": imageName,
-		"tag": tag,
+		"cmd": 			"images remove",
+		"imageName": 	imageName,
+		"tag": 			tag,
 	})
 
 	if imageName == "" {

--- a/pkg/app/image_remove.go
+++ b/pkg/app/image_remove.go
@@ -46,12 +46,19 @@ var CommandRemoveImage = &cli.Command{
 
 func removeImage(clicontext *cli.Context) error {
 	imageName := clicontext.String("image")
+	tag := clicontext.String("tag")
+
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "images remove",
+		"imageName": imageName,
+		"tag": tag,
+	})
+
 	if imageName == "" {
 		return errors.New("image name is required, find images by `envd images list`")
 	}
-	tag := clicontext.String("tag")
 	if tag == "" {
-		logrus.Debug("tag not specified, using default tag: `dev`")
+		logger.Debug("tag not specified, using default tag: `dev`")
 		tag = "dev"
 	}
 	imageNameWithTag := fmt.Sprintf("%s:%s", imageName, tag)
@@ -63,6 +70,6 @@ func removeImage(clicontext *cli.Context) error {
 	if err := dockerClient.RemoveImage(clicontext.Context, imageNameWithTag); err != nil {
 		return errors.Errorf("remove image %s failed: %w", imageNameWithTag, err)
 	}
-	logrus.Infof("image(%s) has removed", imageNameWithTag)
+	logger.Info("image has been removed")
 	return nil
 }

--- a/pkg/app/login.go
+++ b/pkg/app/login.go
@@ -60,8 +60,11 @@ func login(clicontext *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get current context")
 	}
+
+	logger := logrus.WithField("cmd", "login")
+
 	if c.Runner == types.RunnerTypeDocker {
-		logrus.Warn("login is not needed for docker runner, skipping")
+		logger.Warn("login is not needed for docker runner, skipping")
 		return nil
 	}
 	hostAddr := c.RunnerAddress
@@ -84,13 +87,13 @@ func login(clicontext *cli.Context) error {
 	auth := true
 	if pwd == "" {
 		auth = false
-		logrus.Warn("The password is nil, skip the authentication. Please make sure that the server is running in no-auth mode")
+		logger.Warn("The password is nil, skip the authentication. Please make sure that the server is running in no-auth mode")
 		if loginName == "" {
 			loginName, err = generateLoginName()
 			if err != nil {
 				return errors.Wrap(err, "failed to generate the login name")
 			}
-			logrus.Warnf("The login name is nil, use `%s` as the login name", loginName)
+			logger.Warnf("The login name is nil, use `%s` as the login name", loginName)
 		}
 	}
 	req := servertypes.AuthNRequest{
@@ -98,7 +101,7 @@ func login(clicontext *cli.Context) error {
 		Password:  pwd,
 	}
 
-	logger := logrus.WithFields(logrus.Fields{
+	logger = logger.WithFields(logrus.Fields{
 		"login_name":   loginName,
 		"auth-enabled": auth,
 	})
@@ -160,7 +163,7 @@ func login(clicontext *cli.Context) error {
 		}
 	}
 
-	logrus.WithField("key", keyResp.Name).Debug("key is added successfully")
+	logger.WithField("key", keyResp.Name).Debug("key is added successfully")
 	if err := home.GetManager().AuthCreate(types.AuthConfig{
 		Name:     resp.LoginName,
 		JWTToken: resp.IdentityToken,

--- a/pkg/app/pause.go
+++ b/pkg/app/pause.go
@@ -60,7 +60,7 @@ func pause(clicontext *cli.Context) error {
 		return errors.Wrap(err, "failed to pause the environment")
 	}
 	if name != "" {
-		logrus.Infof("%s is paused", name)
+		logrus.WithField("cmd", "pause").Infof("%s is paused", name)
 	}
 	return nil
 }

--- a/pkg/app/resume.go
+++ b/pkg/app/resume.go
@@ -60,7 +60,7 @@ func resume(clicontext *cli.Context) error {
 		return errors.Wrap(err, "failed to pause the environment")
 	}
 	if name != "" {
-		logrus.Infof("%s is resumed", name)
+		logrus.WithField("cmd", "resume").Infof("%s is resumed", name)
 	}
 	return nil
 }

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -171,9 +171,9 @@ func run(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "run",
+		"cmd": 			"run",
 		"StartOptions": opt,
-		"StartResult": res,
+		"StartResult": 	res,
 	})
 
 	logger.Debugf("container %s is running", res.Name)
@@ -296,8 +296,8 @@ func startSyncthing(name string) (*syncthing.Syncthing, *syncthing.Syncthing, er
 	projectName := filepath.Base(cwd)
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cwd": cwd,
-		"projectName": projectName,
+		"cwd": 			cwd,
+		"projectName": 	projectName,
 	})
 
 	localSyncthing, err := syncthing.InitializeLocalSyncthing(name)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -171,9 +171,9 @@ func run(clicontext *cli.Context) error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 			"run",
+		"cmd":          "run",
 		"StartOptions": opt,
-		"StartResult": 	res,
+		"StartResult":  res,
 	})
 
 	logger.Debugf("container %s is running", res.Name)
@@ -296,8 +296,8 @@ func startSyncthing(name string) (*syncthing.Syncthing, *syncthing.Syncthing, er
 	projectName := filepath.Base(cwd)
 
 	logger := logrus.WithFields(logrus.Fields{
-		"cwd": 			cwd,
-		"projectName": 	projectName,
+		"cwd":         cwd,
+		"projectName": projectName,
 	})
 
 	localSyncthing, err := syncthing.InitializeLocalSyncthing(name)

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -203,7 +203,8 @@ func run(clicontext *cli.Context) error {
 		User:               username,
 	}
 	if err = sshconfig.AddEntry(eo); err != nil {
-		logger.Infof("failed to add entry %s to your SSH config file: %s", res.Name, err)
+		logger.WithError(err).
+			Infof("failed to add entry %s to your SSH config file", res.Name)
 		return errors.Wrap(err, "failed to add entry to your SSH config file")
 	}
 
@@ -236,7 +237,7 @@ func run(clicontext *cli.Context) error {
 			}
 			localAddress := fmt.Sprintf("%s:%d", "localhost", localPort)
 			remoteAddress := fmt.Sprintf("%s:%d", "localhost", p.Port)
-			logger.Infof("service \"%s\" is listening at %s\n", p.Name, localAddress)
+			logger.Infof(`service "%s" is listening at %s\n`, p.Name, localAddress)
 			go func() {
 				if err := sshClient.LocalForward(localAddress, remoteAddress); err != nil {
 					outputChannel <- errors.Wrap(err, "failed to forward to local port")

--- a/pkg/app/run.go
+++ b/pkg/app/run.go
@@ -170,9 +170,15 @@ func run(clicontext *cli.Context) error {
 		return err
 	}
 
-	logrus.Debugf("container %s is running", res.Name)
+	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "run",
+		"StartOptions": opt,
+		"StartResult": res,
+	})
 
-	logrus.Debugf("add entry %s to SSH config.", res.Name)
+	logger.Debugf("container %s is running", res.Name)
+
+	logger.Debugf("add entry %s to SSH config.", res.Name)
 	hostname, err := c.GetSSHHostname(opt.SshdHost)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the ssh hostname")
@@ -197,7 +203,7 @@ func run(clicontext *cli.Context) error {
 		User:               username,
 	}
 	if err = sshconfig.AddEntry(eo); err != nil {
-		logrus.Infof("failed to add entry %s to your SSH config file: %s", res.Name, err)
+		logger.Infof("failed to add entry %s to your SSH config file: %s", res.Name, err)
 		return errors.Wrap(err, "failed to add entry to your SSH config file")
 	}
 
@@ -230,7 +236,7 @@ func run(clicontext *cli.Context) error {
 			}
 			localAddress := fmt.Sprintf("%s:%d", "localhost", localPort)
 			remoteAddress := fmt.Sprintf("%s:%d", "localhost", p.Port)
-			logrus.Infof("service \"%s\" is listening at %s\n", p.Name, localAddress)
+			logger.Infof("service \"%s\" is listening at %s\n", p.Name, localAddress)
 			go func() {
 				if err := sshClient.LocalForward(localAddress, remoteAddress); err != nil {
 					outputChannel <- errors.Wrap(err, "failed to forward to local port")
@@ -289,6 +295,11 @@ func startSyncthing(name string) (*syncthing.Syncthing, *syncthing.Syncthing, er
 	}
 	projectName := filepath.Base(cwd)
 
+	logger := logrus.WithFields(logrus.Fields{
+		"cwd": cwd,
+		"projectName": projectName,
+	})
+
 	localSyncthing, err := syncthing.InitializeLocalSyncthing(name)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to initialize local syncthing")
@@ -298,13 +309,13 @@ func startSyncthing(name string) (*syncthing.Syncthing, *syncthing.Syncthing, er
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to initialize remote syncthing")
 	}
-	logrus.Debug("Remote syncthing initialized")
+	logger.Debug("Remote syncthing initialized")
 
 	err = syncthing.ConnectDevices(localSyncthing, remoteSyncthing)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to connect devices")
 	}
-	logrus.Debug("Syncthing devices connected")
+	logger.Debug("Syncthing devices connected")
 
 	err = syncthing.SyncFolder(localSyncthing, remoteSyncthing, cwd, fmt.Sprintf("%s/%s", fileutil.EnvdHomeDir(), projectName))
 	if err != nil {

--- a/pkg/app/telemetry/reporter.go
+++ b/pkg/app/telemetry/reporter.go
@@ -130,9 +130,10 @@ func (r *defaultReporter) dumpTelemetry() error {
 }
 
 func (r *defaultReporter) Identify() {
-	logrus.WithField("UID", r.UID).Debug("telemetry initialization")
+	logger := logrus.WithField("UID", r.UID)
+	logger.Debug("telemetry initialization")
 	if r.enabled {
-		logrus.Debug("sending telemetry")
+		logger.Debug("sending telemetry")
 		v := version.GetVersion()
 		if err := r.client.Enqueue(segmentio.Identify{
 			UserId: r.UID,
@@ -149,7 +150,7 @@ func (r *defaultReporter) Identify() {
 			Timestamp: time.Now(),
 			Traits:    segmentio.NewTraits(),
 		}); err != nil {
-			logrus.Debug("telemetry failed")
+			logger.Debug("telemetry failed")
 			return
 		}
 	}
@@ -163,10 +164,11 @@ func AddField(name string, value interface{}) TelemetryField {
 
 func (r *defaultReporter) Telemetry(command string, fields ...TelemetryField) {
 	if r.enabled {
-		logrus.WithFields(logrus.Fields{
+		logger := logrus.WithFields(logrus.Fields{
 			"UID":     r.UID,
 			"command": command,
-		}).Debug("sending telemetry track event")
+		})
+		logger.Debug("sending telemetry track event")
 		t := segmentio.Track{
 			UserId:     r.UID,
 			Event:      command,
@@ -176,7 +178,7 @@ func (r *defaultReporter) Telemetry(command string, fields ...TelemetryField) {
 			field(&t.Properties)
 		}
 		if err := r.client.Enqueue(t); err != nil {
-			logrus.Debug(err)
+			logger.Debug(err)
 		}
 		// make sure the msg can be sent out
 		r.client.Close()

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -182,6 +182,7 @@ func up(clicontext *cli.Context) error {
 	ctr := filepath.Base(buildOpt.BuildContextDir)
 	detach := clicontext.Bool("detach")
 	logger := logrus.WithFields(logrus.Fields{
+		"cmd": "up",
 		"builder-options": buildOpt,
 		"container-name":  ctr,
 		"detach":          detach,

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -182,10 +182,10 @@ func up(clicontext *cli.Context) error {
 	ctr := filepath.Base(buildOpt.BuildContextDir)
 	detach := clicontext.Bool("detach")
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": 				"up",
-		"builder-options": 	buildOpt,
-		"container-name":  	ctr,
-		"detach":          	detach,
+		"cmd":             "up",
+		"builder-options": buildOpt,
+		"container-name":  ctr,
+		"detach":          detach,
 	})
 	logger.Debug("starting up command")
 

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -206,7 +206,7 @@ func up(clicontext *cli.Context) error {
 		return err
 	}
 
-	logrus.Debug("start running the environment")
+	logger.Debug("start running the environment")
 	// Do not attach GPU if the flag is set.
 	disableGPU := clicontext.Bool("no-gpu")
 	var defaultGPU bool
@@ -272,9 +272,9 @@ func up(clicontext *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to start the envd environment")
 	}
-	logrus.Debugf("container %s is running", res.Name)
+	logger.Debugf("container %s is running", res.Name)
 
-	logrus.Debugf("add entry %s to SSH config.", ctr)
+	logger.Debugf("add entry %s to SSH config.", ctr)
 	hostname, err := c.GetSSHHostname(startOptions.SshdHost)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the ssh hostname")
@@ -286,7 +286,8 @@ func up(clicontext *cli.Context) error {
 		return errors.Wrap(err, "failed to get the ssh entry")
 	}
 	if err = sshconfig.AddEntry(eo); err != nil {
-		logrus.Infof("failed to add entry %s to your SSH config file: %s", ctr, err)
+		logger.WithError(err).
+			Infof("failed to add entry %s to your SSH config file", ctr)
 		return errors.Wrap(err, "failed to add entry to your SSH config file")
 	}
 	telemetry.GetReporter().Telemetry(

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -182,10 +182,10 @@ func up(clicontext *cli.Context) error {
 	ctr := filepath.Base(buildOpt.BuildContextDir)
 	detach := clicontext.Bool("detach")
 	logger := logrus.WithFields(logrus.Fields{
-		"cmd": "up",
-		"builder-options": buildOpt,
-		"container-name":  ctr,
-		"detach":          detach,
+		"cmd": 				"up",
+		"builder-options": 	buildOpt,
+		"container-name":  	ctr,
+		"detach":          	detach,
 	})
 	logger.Debug("starting up command")
 

--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -279,7 +279,7 @@ func (b generalBuilder) build(ctx context.Context, pw progresswriter.Writer) err
 				b.logger.Debug("loading image to docker host")
 				if err := dockerClient.Load(ctx, pipeR, true); err != nil {
 					err = errors.Wrap(err, "failed to load docker image")
-					b.logger.Error(err)
+					b.logger.WithError(err).Error()
 					return err
 				}
 				b.logger.Debug("loaded docker image successfully")
@@ -304,12 +304,12 @@ func (b generalBuilder) build(ctx context.Context, pw progresswriter.Writer) err
 					client, err := docker.NewClient(ctx)
 					if err != nil {
 						err = errors.Wrap(err, "failed to init docker client")
-						b.logger.Error(err)
+						b.logger.WithError(err).Error()
 						return err
 					}
 					if err = client.PushImage(ctx, entry.Attrs["name"], b.Platform); err != nil {
 						err = errors.Wrap(err, "failed to push image")
-						b.logger.Error(err)
+						b.logger.WithError(err).Error()
 						return err
 					}
 					b.logger.Debug("pushed image:", entry.Attrs["name"])

--- a/pkg/builder/dep_check.go
+++ b/pkg/builder/dep_check.go
@@ -31,7 +31,7 @@ func (b generalBuilder) checkIfNeedBuild(ctx context.Context) bool {
 	depsFiles = b.GetDepsFilesHandler(depsFiles)
 	isUpdated, err := b.checkDepsFileUpdate(ctx, b.Tag, b.ManifestFilePath, depsFiles)
 	if err != nil {
-		b.logger.Debugf("failed to check manifest update: %s", err)
+		b.logger.WithError(err).Debug("failed to check manifest update")
 	}
 	if !isUpdated {
 		b.logger.Infof("manifest is not updated, skip building")

--- a/pkg/buildkitd/buildkitd.go
+++ b/pkg/buildkitd/buildkitd.go
@@ -198,7 +198,7 @@ func (c generalClient) waitUntilConnected(
 		case <-time.After(interval):
 			connected, err := c.connected(ctxTimeout)
 			if err != nil {
-				c.logger.Debugf("failed to connect to buildkitd: %s", err.Error())
+				c.logger.WithError(err).Debug("failed to connect to buildkitd")
 				continue
 			}
 			if !connected {

--- a/pkg/buildkitd/buildkitd.go
+++ b/pkg/buildkitd/buildkitd.go
@@ -198,7 +198,7 @@ func (c generalClient) waitUntilConnected(
 		case <-time.After(interval):
 			connected, err := c.connected(ctxTimeout)
 			if err != nil {
-				logrus.Debugf("failed to connect to buildkitd: %s", err.Error())
+				c.logger.Debugf("failed to connect to buildkitd: %s", err.Error())
 				continue
 			}
 			if !connected {

--- a/pkg/driver/nerdctl/nerdctl.go
+++ b/pkg/driver/nerdctl/nerdctl.go
@@ -98,7 +98,7 @@ func (nc *nerdctlClient) StartBuildkitd(ctx context.Context, tag, name string, b
 			"--entrypoint", "sh",
 			tag, "-c", buildkitdCmd)
 		if err != nil {
-			logrus.Error("can not run buildkitd", out, err)
+			logger.WithError(err).Error("can not run buildkitd", out)
 			return "", errors.Wrap(err, "running buildkitd")
 		}
 	}
@@ -185,7 +185,7 @@ func (nc *nerdctlClient) containerInspect(ctx context.Context, tag string) (*typ
 	cs := []types.ContainerJSON{}
 	err = json.Unmarshal([]byte(out), &cs)
 	if err != nil {
-		logrus.Error(cs, err)
+		logrus.WithError(err).Error(cs)
 		return nil, err
 	}
 

--- a/pkg/envd/docker.go
+++ b/pkg/envd/docker.go
@@ -590,7 +590,7 @@ func (e dockerEngine) StartEnvd(ctx context.Context, so StartOptions) (*StartRes
 		errCause := errors.UnwrapAll(err)
 		// Hack to check if the port is already allocated.
 		if strings.Contains(errCause.Error(), "port is already allocated") {
-			logrus.Debugf("failed to allocate the port: %s", err)
+			logger.Debugf("failed to allocate the port: %s", err)
 			return nil, errors.New("port is already allocated in the host")
 		}
 		return nil, errors.Wrap(err, "failed to run the container")
@@ -653,7 +653,7 @@ func (e dockerEngine) Destroy(ctx context.Context, name string) (string, error) 
 	if _, err := e.ImageRemove(ctx, ctr.Image, dockertypes.ImageRemoveOptions{}); err != nil {
 		return "", errors.Errorf("remove image %s failed: %w", ctr.Image, err)
 	}
-	logrus.Infof("image(%s) is destroyed", ctr.Image)
+	logger.Infof("image(%s) is destroyed", ctr.Image)
 
 	return name, nil
 }

--- a/pkg/envd/docker.go
+++ b/pkg/envd/docker.go
@@ -484,7 +484,7 @@ func (e dockerEngine) StartEnvd(ctx context.Context, so StartOptions) (*StartRes
 	if len(so.NumMem) > 0 {
 		mem, err := dockerutils.RAMInBytes(so.NumMem)
 		if err != nil {
-			logger.Infof("parse `memory` error: %v, ignore this argument", err)
+			logger.WithError(err).Info("parse `memory` error, ignore this argument")
 		} else {
 			hostConfig.Memory = mem
 		}
@@ -590,7 +590,7 @@ func (e dockerEngine) StartEnvd(ctx context.Context, so StartOptions) (*StartRes
 		errCause := errors.UnwrapAll(err)
 		// Hack to check if the port is already allocated.
 		if strings.Contains(errCause.Error(), "port is already allocated") {
-			logger.Debugf("failed to allocate the port: %s", err)
+			logger.WithError(err).Debug("failed to allocate the port")
 			return nil, errors.New("port is already allocated in the host")
 		}
 		return nil, errors.Wrap(err, "failed to run the container")

--- a/pkg/envd/envdserver.go
+++ b/pkg/envd/envdserver.go
@@ -185,7 +185,7 @@ func (e envdServerEngine) Attach(name, iface, privateKeyPath string, startResult
 		}
 		localAddress := fmt.Sprintf("%s:%d", "localhost", localPort)
 		remoteAddress := fmt.Sprintf("%s:%d", "localhost", p.Port)
-		logrus.Infof("service \"%s\" is listening at %s\n", p.Name, localAddress)
+		logrus.Infof(`service "%s" is listening at %s\n`, p.Name, localAddress)
 		go func() {
 			if err := sshClient.LocalForward(localAddress, remoteAddress); err != nil {
 				outputChannel <- errors.Wrap(err, "failed to forward to local port")

--- a/pkg/metrics/docker_collector.go
+++ b/pkg/metrics/docker_collector.go
@@ -55,7 +55,8 @@ func (c *dockerCollector) Watch(ctx context.Context, cid string) chan Metrics {
 		defer close(stats)
 		err := c.client.Stats(ctx, cid, stats, c.done)
 		if err != nil {
-			logrus.Error(err)
+			logrus.WithField("cid", cid).
+				WithError(err).Error("error occurred in dockerCollecter.Watch")
 		}
 		c.running = false
 	}()

--- a/pkg/remote/sshd/sshd.go
+++ b/pkg/remote/sshd/sshd.go
@@ -181,7 +181,7 @@ func (srv *Server) connectionHandler(s ssh.Session) {
 
 		err := s.Exit(0)
 		if err != nil {
-			logger.Warningln("exit session with error:", err)
+			logger.WithError(err).Warnln("exit session with error")
 		}
 		return
 	}
@@ -194,7 +194,7 @@ func (srv *Server) connectionHandler(s ssh.Session) {
 
 	err := s.Exit(0)
 	if err != nil {
-		logger.Warningln("exit session with error:", err)
+		logger.WithError(err).Warnln("exit session with error")
 	}
 }
 

--- a/pkg/ssh/config/ssh_config.go
+++ b/pkg/ssh/config/ssh_config.go
@@ -232,7 +232,8 @@ func (config *sshConfig) writeTo(w io.Writer) error {
 func (config *sshConfig) writeToFilepath(p string) error {
 	sshDir := filepath.Dir(p)
 	if err := os.MkdirAll(sshDir, 0700); err != nil {
-		logrus.Infof("failed to create SSH directory %s: %s", sshDir, err)
+		logrus.WithError(err).
+			Infof("failed to create SSH directory %s", sshDir)
 	}
 
 	stat, err := os.Stat(p)
@@ -477,7 +478,7 @@ func save(cfg *sshConfig, path string) error {
 func getSSHConfigPath() string {
 	dirname, err := os.UserHomeDir()
 	if err != nil {
-		logrus.Fatal(err)
+		logrus.WithError(err).Fatal()
 	}
 	return filepath.Join(dirname, ".ssh", "config")
 }

--- a/pkg/ssh/copy.go
+++ b/pkg/ssh/copy.go
@@ -49,13 +49,13 @@ func (c *Copier) Copy() {
 			nw, ew := c.Remote.Write(buf[write:nr])
 			write += nw
 			if ew != nil {
-				logrus.Debugf("write to remote terminal error: %s", ew.Error())
+				logrus.WithError(ew).Debug("write to remote terminal error")
 				<-t.C
 				continue
 			}
 		}
 		if er != nil {
-			logrus.Debugf("read from local to remote terminal error: %s", er.Error())
+			logrus.WithError(er).Debug("read from local to remote terminal error")
 			return
 		}
 	}

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -217,13 +217,13 @@ func (c generalClient) Attach() error {
 		width, height, err = term.GetSize(int(os.Stdout.Fd()))
 		logger.Debugf("terminal width %d height %d", width, height)
 		if err != nil {
-			logger.Debugf("request for terminal size failed: %s", err)
+			logger.WithError(err).Debug("request for terminal size failed")
 		}
 	}
 
 	state, err := term.MakeRaw(termFD)
 	if err != nil {
-		logger.Debugf("request for raw terminal failed: %s", err)
+		logger.WithError(err).Debug("request for raw terminal failed")
 	}
 
 	defer func() {
@@ -232,7 +232,7 @@ func (c generalClient) Attach() error {
 		}
 
 		if err := term.Restore(termFD, state); err != nil {
-			logger.Debugf("failed to restore terminal: %s", err)
+			logger.WithError(err).Debugf("failed to restore terminal")
 		}
 
 		logger.Debugf("terminal restored")
@@ -264,7 +264,7 @@ func (c generalClient) Attach() error {
 		}
 		var emr *ssh.ExitMissingError
 		if ok := errors.As(err, &emr); ok {
-			logger.Debugf("exit status missing: %s", emr)
+			logger.WithError(emr).Debug("exit status missing")
 			return nil
 		}
 		return errors.Wrap(err, "waiting for session failed")
@@ -282,7 +282,7 @@ func (c generalClient) LocalForward(localAddress, targetAddress string) error {
 
 	logger := logrus.WithField("type", "local")
 
-	logger.Debug("begin to forward " + localAddress + " to " + targetAddress)
+	logger.Debugf("begin to forward %s to %s", localAddress, targetAddress)
 	for {
 		localCon, err := localListener.Accept()
 		if err != nil {
@@ -298,7 +298,7 @@ func (c generalClient) LocalForward(localAddress, targetAddress string) error {
 		go func() {
 			_, err = io.Copy(sshConn, localCon)
 			if err != nil {
-				logger.Debugf("io.Copy failed: %v", err)
+				logger.WithError(err).Debug("io.Copy failed")
 			}
 		}()
 
@@ -306,7 +306,7 @@ func (c generalClient) LocalForward(localAddress, targetAddress string) error {
 		go func() {
 			_, err = io.Copy(localCon, sshConn)
 			if err != nil {
-				logger.Debugf("io.Copy failed: %v", err)
+				logger.WithError(err).Debug("io.Copy failed")
 			}
 		}()
 	}
@@ -320,7 +320,7 @@ func (c generalClient) RemoteForward(remoteAddress, targetAddress string) error 
 
 	logger := logrus.WithField("type", "remote")
 
-	logger.Debug("begin to remote forward " + remoteAddress + " to " + targetAddress)
+	logger.Debugf("begin to forward %s to %s", remoteAddress, targetAddress)
 	for {
 		sshCon, err := sshListener.Accept()
 		if err != nil {
@@ -336,7 +336,7 @@ func (c generalClient) RemoteForward(remoteAddress, targetAddress string) error 
 		go func() {
 			_, err = io.Copy(targetCon, sshCon)
 			if err != nil {
-				logger.Debugf("io.Copy failed: %v", err)
+				logger.WithError(err).Debug("io.Copy failed")
 			}
 		}()
 
@@ -344,7 +344,7 @@ func (c generalClient) RemoteForward(remoteAddress, targetAddress string) error 
 		go func() {
 			_, err = io.Copy(sshCon, targetCon)
 			if err != nil {
-				logger.Debugf("io.Copy failed: %v", err)
+				logger.WithError(err).Debug("io.Copy failed")
 			}
 		}()
 	}

--- a/pkg/syncthing/client.go
+++ b/pkg/syncthing/client.go
@@ -56,7 +56,7 @@ func (c *Client) SendRequest(method string, url string, params map[string]string
 		"method": method,
 		"url":    url,
 		"params": params,
-	}).Debug("calling syncthing API: ", url)
+	}).Debug("calling syncthing API")
 	// TODO: can implement retry logic
 
 	var urlPath = c.BasePath + url

--- a/pkg/syncthing/client.go
+++ b/pkg/syncthing/client.go
@@ -53,9 +53,9 @@ func (s *Syncthing) NewClient() *Client {
 // Makes API calls to the syncthing instance's rest api
 func (c *Client) SendRequest(method string, url string, params map[string]string, body []byte) ([]byte, error) {
 	logrus.WithFields(logrus.Fields{
-		"method": 	method,
-		"url": 		url,
-		"params": 	params,
+		"method": method,
+		"url":    url,
+		"params": params,
 	}).Debug("calling syncthing API: ", url)
 	// TODO: can implement retry logic
 

--- a/pkg/syncthing/client.go
+++ b/pkg/syncthing/client.go
@@ -52,7 +52,11 @@ func (s *Syncthing) NewClient() *Client {
 
 // Makes API calls to the syncthing instance's rest api
 func (c *Client) SendRequest(method string, url string, params map[string]string, body []byte) ([]byte, error) {
-	logrus.Debug("calling syncthing API: ", url)
+	logrus.WithFields(logrus.Fields{
+		"method": 	method,
+		"url": 		url,
+		"params": 	params,
+	}).Debug("calling syncthing API: ", url)
 	// TODO: can implement retry logic
 
 	var urlPath = c.BasePath + url

--- a/pkg/syncthing/config.go
+++ b/pkg/syncthing/config.go
@@ -90,7 +90,8 @@ func (s *Syncthing) WaitForConfigApply(timeout time.Duration) error {
 	start := time.Now()
 	for {
 		if time.Since(start) > timeout {
-			logrus.Debug("Timeout reached, config not applied")
+			logrus.WithField("timeout", timeout).
+				Debug("Timeout reached, config not applied")
 			return fmt.Errorf("timed out waiting for configurations to apply")
 		}
 

--- a/pkg/syncthing/device.go
+++ b/pkg/syncthing/device.go
@@ -23,10 +23,10 @@ import (
 
 func ConnectDevices(s1 *Syncthing, s2 *Syncthing) error {
 	logger := logrus.WithFields(logrus.Fields{
-		"s1": 			s1.Name,
-		"s2": 			s2.Name,
-		"config-s1": 	s1.Config,
-		"config-s2": 	s2.Config,
+		"s1":        s1.Name,
+		"s2":        s2.Name,
+		"config-s1": s1.Config,
+		"config-s2": s2.Config,
 	})
 	logger.Debug("Connecting syncthings")
 	var err error

--- a/pkg/syncthing/device.go
+++ b/pkg/syncthing/device.go
@@ -22,20 +22,26 @@ import (
 )
 
 func ConnectDevices(s1 *Syncthing, s2 *Syncthing) error {
-	logrus.Debug(fmt.Sprintf("Connecting syncthings %s and %s", s1.Name, s2.Name))
+	logger := logrus.WithFields(logrus.Fields{
+		"s1": 			s1.Name,
+		"s2": 			s2.Name,
+		"config-s1": 	s1.Config,
+		"config-s2": 	s2.Config,
+	})
+	logger.Debug("Connecting syncthings")
 	var err error
 	connectedDevices := append(s1.Config.Devices, s2.Config.Devices...)
 
 	s1.Config.Devices = connectedDevices
 	s2.Config.Devices = connectedDevices
 
-	logrus.Debug("Adding device config for: ", s1.Name)
+	logger.Debug("Adding device config for: ", s1.Name)
 	err = s1.ApplyConfig()
 	if err != nil {
 		return err
 	}
 
-	logrus.Debug("Adding device config for: ", s2.Name)
+	logger.Debug("Adding device config for: ", s2.Name)
 	err = s2.ApplyConfig()
 	if err != nil {
 		return err

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -207,13 +207,7 @@ func (s *Syncthing) StartLocalSyncthing() error {
 func (s *Syncthing) Ping() (bool, error) {
 	_, err := s.Client.SendRequest(GET, "/rest/system/ping", nil, nil)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{
-			"name":    s.Name,
-			"port":    s.Port,
-			"homedir": s.HomeDirectory,
-			"apikey":  s.ApiKey,
-			"config":  s.Config,
-		}).Debug("Failed to ping syncthing: ", err)
+		logrus.Debug("Failed to ping syncthing")
 		return false, fmt.Errorf("failed to ping syncthing: %w", err)
 	}
 

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -51,11 +51,11 @@ func InitializeRemoteSyncthing() (*Syncthing, error) {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"name": 	s.Name,
-		"port": 	s.Port,
-		"homedir": 	s.HomeDirectory,
-		"apikey": 	s.ApiKey,
-		"config":	s.Config,
+		"name":    s.Name,
+		"port":    s.Port,
+		"homedir": s.HomeDirectory,
+		"apikey":  s.ApiKey,
+		"config":  s.Config,
 	})
 
 	s.Client = s.NewClient()
@@ -105,11 +105,11 @@ func InitializeLocalSyncthing(name string) (*Syncthing, error) {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"name": 	s.Name,
-		"port": 	s.Port,
-		"homedir": 	s.HomeDirectory,
-		"apikey": 	s.ApiKey,
-		"config":	s.Config,
+		"name":    s.Name,
+		"port":    s.Port,
+		"homedir": s.HomeDirectory,
+		"apikey":  s.ApiKey,
+		"config":  s.Config,
 	})
 
 	s.Client = s.NewClient()
@@ -159,11 +159,11 @@ func (s *Syncthing) StartLocalSyncthing() error {
 	}
 
 	logger := logrus.WithFields(logrus.Fields{
-		"name": 	s.Name,
-		"port": 	s.Port,
-		"homedir": 	s.HomeDirectory,
-		"apikey": 	s.ApiKey,
-		"config":	s.Config,
+		"name":    s.Name,
+		"port":    s.Port,
+		"homedir": s.HomeDirectory,
+		"apikey":  s.ApiKey,
+		"config":  s.Config,
 	})
 
 	logger.Debug("Starting local syncthing...")
@@ -208,11 +208,11 @@ func (s *Syncthing) Ping() (bool, error) {
 	_, err := s.Client.SendRequest(GET, "/rest/system/ping", nil, nil)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
-			"name": 	s.Name,
-			"port": 	s.Port,
-			"homedir": 	s.HomeDirectory,
-			"apikey": 	s.ApiKey,
-			"config":	s.Config,
+			"name":    s.Name,
+			"port":    s.Port,
+			"homedir": s.HomeDirectory,
+			"apikey":  s.ApiKey,
+			"config":  s.Config,
 		}).Debug("Failed to ping syncthing: ", err)
 		return false, fmt.Errorf("failed to ping syncthing: %w", err)
 	}
@@ -225,11 +225,11 @@ func (s *Syncthing) WaitForStartup(timeout time.Duration) error {
 	for {
 		if time.Since(start) > timeout {
 			logrus.WithFields(logrus.Fields{
-				"name": 	s.Name,
-				"port": 	s.Port,
-				"homedir": 	s.HomeDirectory,
-				"apikey": 	s.ApiKey,
-				"config":	s.Config,
+				"name":    s.Name,
+				"port":    s.Port,
+				"homedir": s.HomeDirectory,
+				"apikey":  s.ApiKey,
+				"config":  s.Config,
 			}).Debugf("Timeout reached for syncthing: %s", s.Name)
 			return fmt.Errorf("timed out waiting for syncthing to start")
 		}
@@ -242,11 +242,11 @@ func (s *Syncthing) WaitForStartup(timeout time.Duration) error {
 
 func (s *Syncthing) StopLocalSyncthing() {
 	logger := logrus.WithFields(logrus.Fields{
-		"name": 	s.Name,
-		"port": 	s.Port,
-		"homedir": 	s.HomeDirectory,
-		"apikey": 	s.ApiKey,
-		"config":	s.Config,
+		"name":    s.Name,
+		"port":    s.Port,
+		"homedir": s.HomeDirectory,
+		"apikey":  s.ApiKey,
+		"config":  s.Config,
 	})
 	if s.Cmd == nil {
 		logger.Error("syncthing is not running")
@@ -254,7 +254,7 @@ func (s *Syncthing) StopLocalSyncthing() {
 
 	err := s.Cmd.Process.Signal(syscall.SIGINT)
 	if err != nil {
-		logger.WithError(err).Error("failed ot kill syncthing process")
+		logger.WithError(err).Error("failed to kill syncthing process")
 	}
 
 	_, err = s.Cmd.Process.Wait()

--- a/pkg/syncthing/syncthing.go
+++ b/pkg/syncthing/syncthing.go
@@ -114,7 +114,7 @@ func InitializeLocalSyncthing(name string) (*Syncthing, error) {
 
 	s.Client = s.NewClient()
 
-	logger.Debug("Port for local syncthing is: ", initConfig.GUI.Address())
+	logger.Debugf("Port for local syncthing is: %s", initConfig.GUI.Address())
 
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func (s *Syncthing) StartLocalSyncthing() error {
 func (s *Syncthing) Ping() (bool, error) {
 	_, err := s.Client.SendRequest(GET, "/rest/system/ping", nil, nil)
 	if err != nil {
-		logrus.Debug("Failed to ping syncthing")
+		logrus.WithError(err).Debug("Failed to ping syncthing")
 		return false, fmt.Errorf("failed to ping syncthing: %w", err)
 	}
 
@@ -224,7 +224,7 @@ func (s *Syncthing) WaitForStartup(timeout time.Duration) error {
 				"homedir": s.HomeDirectory,
 				"apikey":  s.ApiKey,
 				"config":  s.Config,
-			}).Debugf("Timeout reached for syncthing: %s", s.Name)
+			}).Debugf("Timeout reached for syncthing")
 			return fmt.Errorf("timed out waiting for syncthing to start")
 		}
 		if ok, _ := s.Ping(); ok {

--- a/pkg/util/osutil/wsl.go
+++ b/pkg/util/osutil/wsl.go
@@ -34,7 +34,7 @@ func IsWsl() bool {
 	cmd := exec.Command("cat", "/proc/version")
 	output, err := cmd.Output()
 	if err != nil {
-		logrus.Debugf("Error when check whether sys is WSL: %v", err)
+		logrus.WithError(err).Error("Error when check whether sys is WSL")
 		return false
 	}
 


### PR DESCRIPTION
This PR is related to issue #889 . 

I changed the remaining unstructured logging to structured logging, covering nearly all of the files under directory `/cmd` and `/pkg`.

Typical changes:
- `logrus.Debug/Info/Warn()` -> `logger := logrus.WithFields()` & `logger.Debug/Info/Warn()`
- `logrus.Error/Fatal()` -> `logger := logrus.WithFields()` & `logger.WithError().Error/Fatal()`
- Newly added k-v pairs in `WithField()` and `WithFields()`

PTAL.