### PR TITLE
feat: envd up with --gpu-set

### DIFF
--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -126,6 +126,11 @@ var CommandUp = &cli.Command{
 			Usage: "Number of GPUs used in this environment, this will override the `config.gpu()`",
 			Value: 0,
 		},
+		&cli.StringFlag{
+			Name:  "gpu-set",
+			Usage: "GPU devices used in this environment, such as `all`, `'\"device=1,3\"'`, `count=2`(all to pass all GPUs). This will override the `--gpus`",
+			Value: "",
+		},
 		&cli.BoolFlag{
 			Name:  "force",
 			Usage: "Force rebuild and run the container although the previous container is running",
@@ -228,6 +233,11 @@ func up(clicontext *cli.Context) error {
 		numGPU = cliGPU
 	}
 
+	gpuSet := ""
+	if defaultGPU {
+		gpuSet = clicontext.String("gpu-set")
+	}
+
 	shmSize := builder.ShmSize()
 	isSetShmSize := clicontext.IsSet("shm-size")
 	if shmSize == 0 || isSetShmSize {
@@ -253,6 +263,7 @@ func up(clicontext *cli.Context) error {
 		BuildContext:    buildOpt.BuildContextDir,
 		Image:           buildOpt.Tag,
 		NumGPU:          numGPU,
+		GPUSet:          gpuSet,
 		Forced:          clicontext.Bool("force"),
 		Timeout:         clicontext.Duration("timeout"),
 		SshdHost:        clicontext.String("host"),

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -221,18 +221,19 @@ func up(clicontext *cli.Context) error {
 	} else {
 		defaultGPU = builder.GPUEnabled()
 	}
-	gpuSet := ""
+	numGPU := 0
 	if defaultGPU {
-		gpuSet = "1"
+		numGPU = 1
 	}
 	configGPU := builder.NumGPUs()
 	if defaultGPU && configGPU != 0 {
-		gpuSet = strconv.Itoa(configGPU)
+		numGPU = configGPU
 	}
 	cliGPU := clicontext.Int("gpus")
 	if defaultGPU && cliGPU != 0 {
-		gpuSet = strconv.Itoa(cliGPU)
+		numGPU = cliGPU
 	}
+	gpuSet := strconv.Itoa(numGPU)
 	cliGPUSet := clicontext.String("gpu-set")
 	if defaultGPU && len(cliGPUSet) > 0 {
 		gpuSet = cliGPUSet
@@ -262,6 +263,7 @@ func up(clicontext *cli.Context) error {
 		EnvironmentName: name,
 		BuildContext:    buildOpt.BuildContextDir,
 		Image:           buildOpt.Tag,
+		NumGPU:          numGPU,
 		GPUSet:          gpuSet,
 		Forced:          clicontext.Bool("force"),
 		Timeout:         clicontext.Duration("timeout"),

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -17,6 +17,7 @@ package app
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -220,22 +221,21 @@ func up(clicontext *cli.Context) error {
 	} else {
 		defaultGPU = builder.GPUEnabled()
 	}
-	numGPU := 0
+	gpuSet := ""
 	if defaultGPU {
-		numGPU = 1
+		gpuSet = "1"
 	}
 	configGPU := builder.NumGPUs()
 	if defaultGPU && configGPU != 0 {
-		numGPU = configGPU
+		gpuSet = strconv.Itoa(configGPU)
 	}
 	cliGPU := clicontext.Int("gpus")
 	if defaultGPU && cliGPU != 0 {
-		numGPU = cliGPU
+		gpuSet = strconv.Itoa(cliGPU)
 	}
-
-	gpuSet := ""
-	if defaultGPU {
-		gpuSet = clicontext.String("gpu-set")
+	cliGPUSet := clicontext.String("gpu-set")
+	if defaultGPU && len(cliGPUSet) > 0 {
+		gpuSet = cliGPUSet
 	}
 
 	shmSize := builder.ShmSize()
@@ -262,7 +262,6 @@ func up(clicontext *cli.Context) error {
 		EnvironmentName: name,
 		BuildContext:    buildOpt.BuildContextDir,
 		Image:           buildOpt.Tag,
-		NumGPU:          numGPU,
 		GPUSet:          gpuSet,
 		Forced:          clicontext.Bool("force"),
 		Timeout:         clicontext.Duration("timeout"),

--- a/pkg/app/up.go
+++ b/pkg/app/up.go
@@ -233,7 +233,10 @@ func up(clicontext *cli.Context) error {
 	if defaultGPU && cliGPU != 0 {
 		numGPU = cliGPU
 	}
-	gpuSet := strconv.Itoa(numGPU)
+	gpuSet := ""
+	if defaultGPU && numGPU != 0 {
+		gpuSet = strconv.Itoa(numGPU)
+	}
 	cliGPUSet := clicontext.String("gpu-set")
 	if defaultGPU && len(cliGPUSet) > 0 {
 		gpuSet = cliGPUSet

--- a/pkg/envd/docker.go
+++ b/pkg/envd/docker.go
@@ -350,7 +350,6 @@ func (e dockerEngine) StartEnvd(ctx context.Context, so StartOptions) (*StartRes
 	logger := logrus.WithFields(logrus.Fields{
 		"tag":           so.Image,
 		"environment":   so.EnvironmentName,
-		"gpu":           so.NumGPU,
 		"gpu-set":       so.GPUSet,
 		"shm":           so.ShmSize,
 		"cpu":           so.NumCPU,
@@ -363,7 +362,7 @@ func (e dockerEngine) StartEnvd(ctx context.Context, so StartOptions) (*StartRes
 	defer bar.Finish()
 	bar.UpdateTitle("configure the environment")
 
-	if len(so.GPUSet) > 0 || so.NumGPU != 0 {
+	if len(so.GPUSet) > 0 {
 		nvruntimeExists, err := e.GPUEnabled(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to check if nvidia-runtime is installed")
@@ -562,15 +561,9 @@ func (e dockerEngine) StartEnvd(ctx context.Context, so StartOptions) (*StartRes
 		}
 	}
 
-	if len(so.GPUSet) > 0 || so.NumGPU != 0 {
+	if len(so.GPUSet) > 0 {
 		logger.Debug("GPU is enabled.")
-		var value string
-		if len(so.GPUSet) > 0 {
-			value = so.GPUSet
-		} else {
-			value = strconv.Itoa(so.NumGPU)
-		}
-		hostConfig.DeviceRequests, err = deviceRequests(value)
+		hostConfig.DeviceRequests, err = deviceRequests(so.GPUSet)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to parse gpu-set flag")
 

--- a/pkg/envd/docker_test.go
+++ b/pkg/envd/docker_test.go
@@ -1,0 +1,149 @@
+package envd
+
+import (
+	"github.com/docker/docker/api/types/container"
+	"reflect"
+	"testing"
+)
+
+func TestDeviceRequests(t *testing.T) {
+	type args struct {
+		value string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []container.DeviceRequest
+		wantErr bool
+	}{
+		{
+			name: "device=1",
+			args: args{
+				value: "device=1",
+			},
+			want: []container.DeviceRequest{
+				{
+					Count:     0,
+					DeviceIDs: []string{"1"},
+					Driver:    "nvidia",
+					Capabilities: [][]string{
+						{"nvidia", "compute", "compat32", "graphics", "utility", "video", "display", "gpu"}},
+					Options: make(map[string]string),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "device=1,3",
+			args: args{
+				value: "\"device=1,3\"",
+			},
+			want: []container.DeviceRequest{
+				{
+					Count:     0,
+					DeviceIDs: []string{"1", "3"},
+					Driver:    "nvidia",
+					Capabilities: [][]string{
+						{"nvidia", "compute", "compat32", "graphics", "utility", "video", "display", "gpu"}},
+					Options: make(map[string]string),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "all",
+			args: args{
+				value: "all",
+			},
+			want: []container.DeviceRequest{
+				{
+					Count:  -1,
+					Driver: "nvidia",
+					Capabilities: [][]string{
+						{"nvidia", "compute", "compat32", "graphics", "utility", "video", "display", "gpu"}},
+					Options: make(map[string]string),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "3",
+			args: args{
+				value: "3",
+			},
+			want: []container.DeviceRequest{
+				{
+					Count:  3,
+					Driver: "nvidia",
+					Capabilities: [][]string{
+						{"nvidia", "compute", "compat32", "graphics", "utility", "video", "display", "gpu"}},
+					Options: make(map[string]string),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "count=5",
+			args: args{
+				value: "count=5",
+			},
+			want: []container.DeviceRequest{
+				{
+					Count:  5,
+					Driver: "nvidia",
+					Capabilities: [][]string{
+						{"nvidia", "compute", "compat32", "graphics", "utility", "video", "display", "gpu"}},
+					Options: make(map[string]string),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "device=1,3 with driver",
+			args: args{
+				value: "\"device=1,3\",\"driver=custom\"",
+			},
+			want: []container.DeviceRequest{
+				{
+					Count:     0,
+					DeviceIDs: []string{"1", "3"},
+					Driver:    "custom",
+					Capabilities: [][]string{
+						{"nvidia", "compute", "compat32", "graphics", "utility", "video", "display", "gpu"}},
+					Options: make(map[string]string),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "device=1,3 with capabilities",
+			args: args{
+				value: "\"device=1,3\",\"capabilities=nvidia\"",
+			},
+			want: []container.DeviceRequest{
+				{
+					Count:     0,
+					DeviceIDs: []string{"1", "3"},
+					Driver:    "nvidia",
+					Capabilities: [][]string{
+						{"nvidia", "gpu"},
+					},
+					Options: make(map[string]string),
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := deviceRequests(tt.args.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deviceRequests() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("deviceRequests() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/envd/docker_test.go
+++ b/pkg/envd/docker_test.go
@@ -1,3 +1,17 @@
+// Copyright 2024 The envd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package envd
 
 import (

--- a/pkg/envd/docker_test.go
+++ b/pkg/envd/docker_test.go
@@ -15,9 +15,10 @@
 package envd
 
 import (
-	"github.com/docker/docker/api/types/container"
 	"reflect"
 	"testing"
+
+	"github.com/docker/docker/api/types/container"
 )
 
 func TestDeviceRequests(t *testing.T) {

--- a/pkg/envd/types.go
+++ b/pkg/envd/types.go
@@ -37,6 +37,7 @@ type StartOptions struct {
 	Image           string
 	EnvironmentName string
 	BuildContext    string
+	NumGPU          int
 	GPUSet          string
 	NumCPU          string
 	CPUSet          string

--- a/pkg/envd/types.go
+++ b/pkg/envd/types.go
@@ -38,6 +38,7 @@ type StartOptions struct {
 	EnvironmentName string
 	BuildContext    string
 	NumGPU          int
+	GPUSet          string
 	NumCPU          string
 	CPUSet          string
 	NumMem          string

--- a/pkg/envd/types.go
+++ b/pkg/envd/types.go
@@ -37,7 +37,6 @@ type StartOptions struct {
 	Image           string
 	EnvironmentName string
 	BuildContext    string
-	NumGPU          int
 	GPUSet          string
 	NumCPU          string
 	CPUSet          string


### PR DESCRIPTION
### Command help
```text
[user@localhost test]$ envd up -h
NAME:
   envd up - Build and run the envd environment

USAGE:
   envd up [command options] [arguments...]

CATEGORY:
   Basic Commands

OPTIONS:
   --tag value, -t value                                                     Name and optionally a tag in the 'name:tag' format (default: PROJECT:dev)
   --name value                                                              environment name
   --path value, -p value                                                    Path to the directory containing the build.envd (default: ".")
   --volume value, -v value [ --volume value, -v value ]                     Mount host directory into container
   --from file:func, -f file:func                                            Function to execute, format file:func (default: "build.envd:build")
   --use-proxy, --proxy                                                      Use HTTPS_PROXY/HTTP_PROXY/NO_PROXY in the build process (default: false)
   --timeout value                                                           Timeout of container creation (default: 30s)
   --shm-size value                                                          Configure the shared memory size (megabyte) (default: 2048)
   --cpus value                                                              Request CPU resources (number of cores), such as 0.5, 1, 2
   --cpu-set 0-3                                                             Limit the specific CPUs or cores the environment can use, such as 0-3, `1,3`
   --memory value                                                            Request Memory, such as 512Mb, 2Gb
   --detach                                                                  Detach from the container (default: false)
   --no-gpu                                                                  Launch the CPU container even if it's a GPU image (default: false)
   --gpus config.gpu()                                                       Number of GPUs used in this environment, this will override the config.gpu() (default: 0)
   --gpu-set all                                                             GPU devices used in this environment, such as all, `'"device=1,3"'`, `count=2`(all to pass all GPUs). This will override the `--gpus`
   --force                                                                   Force rebuild and run the container although the previous container is running (default: false)
   --host value                                                              Assign the host address for the environment SSH access server listening (default: "127.0.0.1")
   --export-cache type=registry,ref=<image>, --ec type=registry,ref=<image>  Export the cache (e.g. type=registry,ref=<image>)
   --import-cache type=registry,ref=<image>, --ic type=registry,ref=<image>  Import the cache (e.g. type=registry,ref=<image>)
   --platform value                                                          Specify the target platform for the build output, (for example, windows/amd64, linux/amd64, or darwin/arm64) (default: linux/amd64)
   --help, -h                                                                show help
```

### Use example

1. `envd up --gpu-set all`
<img width="1666" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/e3f19b0a-fcb8-46c7-9486-7ffa8cc1e2f0">
<img width="1636" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/a7871781-4397-4b29-b911-b0c5279ef3cb">

2. `envd up --gpu-set '"device=1,3"'`
<img width="1679" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/0305ba1b-6d74-4ab7-93db-c0cb18f1cd8e">
<img width="1667" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/bc247e28-5f24-4f50-a765-bd3294244b49">

3. `envd up --gpu-set count=2`
<img width="1679" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/f0601c53-d010-4224-b34b-a33576191a0d">
<img width="1674" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/4081bfc8-cc67-40af-8f3f-f1a3aa8985c8">

4. `envd up --gpu-set '"device=2,3"' --gpus 1`
<img width="1662" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/4b136ce0-8b8e-4d2d-b1c0-32414ff075d7">
<img width="1678" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/a8b55ac3-3f6c-4421-ba77-5f0bf454f49e">

5. `envd up --gpts 4`
<img width="1651" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/4cc61259-1ef7-4e0b-a27e-398be45ac314">
<img width="1676" alt="image" src="https://github.com/tensorchord/envd/assets/26432832/71b3716d-0464-46c6-8f7a-80b601c9a8df">


### Issues
Closes: #1810 