### PR TITLE
Enabling userns_host

### DIFF
--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -283,6 +283,7 @@ func (c dockerClient) StartBuildkitd(ctx context.Context, tag, name string, bc *
 	hostConfig := &container.HostConfig{
 		Privileged: true,
 		AutoRemove: true,
+        UsernsMode: "host",
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,


### PR DESCRIPTION
Buildkit bootstrap is failing when docker user namespace mapping is enabled:

```
failed to create the builder: failed to create buildkit client: failed to bootstrap the buildkitd: failed to create container: Error response from daemon: privileged mode is incompatible with user namespaces.  You must run the container in the host namespace when running privileged mode
```

This PR is passing `--userns host` to the docker startup command to prevent this.


