### PR TITLE
feat: upgrade to python 3.11

### DIFF
--- a/e2e/v0/cli/testdata/custom-image-test/build.envd
+++ b/e2e/v0/cli/testdata/custom-image-test/build.envd
@@ -1,5 +1,5 @@
 def build():
-    base(language="python", image="python:3.9-slim")
+    base(language="python", image="python:3.11-slim")
     install.python_packages(
         name=[
             "via",

--- a/e2e/v1/cli/testdata/custom-image-test/build.envd
+++ b/e2e/v1/cli/testdata/custom-image-test/build.envd
@@ -2,7 +2,7 @@
 
 
 def build():
-    base(image="python:3.9-slim", dev=False)
+    base(image="python:3.11-slim", dev=False)
     install.python_packages(
         name=[
             "via",

--- a/envd/api/v0/__init__.py
+++ b/envd/api/v0/__init__.py
@@ -30,7 +30,7 @@ def base(os: str, language: str, image: Optional[str]):
     Args:
         os (str): The operating system (i.e. `ubuntu20.04`)
         language (str): The programming language dependency (i.e. `python3.8`)
-        image (Optional[str]): Custom image (i.e. `python:3.9-slim`)
+        image (Optional[str]): Custom image (i.e. `python:3.11-slim`)
     """
 
 

--- a/envd/api/v1/install.py
+++ b/envd/api/v1/install.py
@@ -30,7 +30,7 @@ v1 is experimental and may change in the future. Make sure to freeze the envd ve
 from typing import Optional, Sequence
 
 
-def python(version: str = "3.9"):
+def python(version: str = "3.11"):
     """Install python.
 
     If `install.conda` is not used, this will create a solo Python environment. Otherwise, it

--- a/examples/custom-image/build.envd
+++ b/examples/custom-image/build.envd
@@ -1,5 +1,5 @@
 def build():
-    base(language="python", image="python:3.9-slim")
+    base(language="python", image="python:3.11-slim")
     install.python_packages(
         name=[
             "via",

--- a/examples/dpgen2/build.envd
+++ b/examples/dpgen2/build.envd
@@ -23,7 +23,7 @@ def install_kubectl_kind(env_name):
 
 
 def build():
-    base(os="ubuntu20.04", language="python3.9")
+    base(os="ubuntu20.04", language="python3.11")
     install.python_packages(
         name=[
             "pydflow",

--- a/pkg/lang/ir/v0/conda.go
+++ b/pkg/lang/ir/v0/conda.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	condaVersionDefault = "py39_4.11.0"
+	condaVersionDefault = "py311_24.11.1-0"
 	// check the issue https://github.com/mamba-org/mamba/issues/1975
 	mambaVersionDefault = "0.25.1"
 	condaRootPrefix     = "/opt/conda"

--- a/pkg/lang/ir/v0/install-conda.sh
+++ b/pkg/lang/ir/v0/install-conda.sh
@@ -2,16 +2,13 @@ set -euo pipefail && \
 UNAME_M="$(uname -m)" && \
 if [ "${UNAME_M}" = "x86_64" ]; then \
 	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \
-	SHA256SUM="4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4"; \
+	SHA256SUM="807774bae6cd87132094458217ebf713df436f64779faf9bb4c3d4b6615c1e3a"; \
 elif [ "${UNAME_M}" = "s390x" ]; then \
 	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-s390x.sh"; \
-	SHA256SUM="e5e5e89cdcef9332fe632cd25d318cf71f681eef029a24495c713b18e66a8018"; \
+	SHA256SUM="bb499b18dbcbb2d89b22f91fe26fe661f5ed1f1944fdc743560d69cd52a2468f"; \
 elif [ "${UNAME_M}" = "aarch64" ]; then \
 	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-aarch64.sh"; \
-	SHA256SUM="00c7127a8a8d3f4b9c2ab3391c661239d5b9a88eafe895fd0f3f2a8d9c0f4556"; \
-elif [ "${UNAME_M}" = "ppc64le" ]; then \
-	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-ppc64le.sh"; \
-	SHA256SUM="8ee1f8d17ef7c8cb08a85f7d858b1cb55866c06fcf7545b98c3b82e4d0277e66"; \
+	SHA256SUM="a8846ade7a5ddd9b6a6546590054d70d1c2cbe4fbe8c79fb70227e8fd93ef9f8"; \
 fi && \
 wget "${MINICONDA_URL}" -O /tmp/miniconda.sh && \
 echo "${SHA256SUM} /tmp/miniconda.sh" > /tmp/shasum && \

--- a/pkg/lang/ir/v0/python.go
+++ b/pkg/lang/ir/v0/python.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	pythonVersionDefault = "3.9"
+	pythonVersionDefault = "3.11"
 )
 
 func (g generalGraph) getAppropriatePythonVersion() (string, error) {

--- a/pkg/lang/ir/v1/conda.go
+++ b/pkg/lang/ir/v1/conda.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	builderImage        = "curlimages/curl:7.86.0"
-	condaVersionDefault = "py39_4.11.0"
+	condaVersionDefault = "py311_24.11.1-0"
 	microMambaImage     = "mambaorg/micromamba:1.0.0"
 	condaRootPrefix     = "/opt/conda"
 	condaBinDir         = "/opt/conda/bin"

--- a/pkg/lang/ir/v1/get_conda.sh
+++ b/pkg/lang/ir/v1/get_conda.sh
@@ -2,16 +2,13 @@ set -euo pipefail && \
 UNAME_M="$(uname -m)" && \
 if [ "${UNAME_M}" = "x86_64" ]; then \
 	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh"; \
-	SHA256SUM="4ee9c3aa53329cd7a63b49877c0babb49b19b7e5af29807b793a76bdb1d362b4"; \
+	SHA256SUM="807774bae6cd87132094458217ebf713df436f64779faf9bb4c3d4b6615c1e3a"; \
 elif [ "${UNAME_M}" = "s390x" ]; then \
 	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-s390x.sh"; \
-	SHA256SUM="e5e5e89cdcef9332fe632cd25d318cf71f681eef029a24495c713b18e66a8018"; \
+	SHA256SUM="bb499b18dbcbb2d89b22f91fe26fe661f5ed1f1944fdc743560d69cd52a2468f"; \
 elif [ "${UNAME_M}" = "aarch64" ]; then \
 	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-aarch64.sh"; \
-	SHA256SUM="00c7127a8a8d3f4b9c2ab3391c661239d5b9a88eafe895fd0f3f2a8d9c0f4556"; \
-elif [ "${UNAME_M}" = "ppc64le" ]; then \
-	MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${CONDA_VERSION}-Linux-ppc64le.sh"; \
-	SHA256SUM="8ee1f8d17ef7c8cb08a85f7d858b1cb55866c06fcf7545b98c3b82e4d0277e66"; \
+	SHA256SUM="a8846ade7a5ddd9b6a6546590054d70d1c2cbe4fbe8c79fb70227e8fd93ef9f8"; \
 fi && \
 wget "${MINICONDA_URL}" -O /tmp/miniconda.sh && \
 echo "${SHA256SUM}  /tmp/miniconda.sh" > /tmp/shasum && \

--- a/pkg/lang/ir/v1/python.go
+++ b/pkg/lang/ir/v1/python.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	PythonVersionDefault = "3.9"
+	PythonVersionDefault = "3.11"
 	microMambaPathPrefix = "/usr/local/bin"
 	certPath             = "/etc/ssl/certs"
 )

--- a/setup.py
+++ b/setup.py
@@ -88,12 +88,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 


### PR DESCRIPTION
Python 3.9 will reach the EOL this October:
- https://www.python.org/downloads/

Most of the machine learning libraries should have 3.11 support.

WDYT cc @gaocegege 