### PR TITLE
fix: sshd handle the error

### DIFF
--- a/pkg/lang/ir/v1/pixi.go
+++ b/pkg/lang/ir/v1/pixi.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	pixiVersion        = "0.45.0"
+	pixiVersion        = "0.48.0"
 	pixiConfigTemplate = `
 {{- if .UsePixiMirror -}}
 [mirrors]

--- a/pkg/lang/ir/v1/uv.go
+++ b/pkg/lang/ir/v1/uv.go
@@ -17,7 +17,7 @@ package v1
 import "github.com/moby/buildkit/client/llb"
 
 const (
-	uvVersion = "0.6.5"
+	uvVersion = "0.7.10"
 )
 
 func (g generalGraph) compileUV(root llb.State) llb.State {

--- a/pkg/remote/sshd/sshd.go
+++ b/pkg/remote/sshd/sshd.go
@@ -256,13 +256,13 @@ func setWinSize(f *os.File, w, h int) {
 	}
 }
 
-func sendErrAndExit(logger *logrus.Entry, s ssh.Session, err error) {
-	msg := strings.TrimPrefix(err.Error(), "exec: ")
+func sendErrAndExit(logger *logrus.Entry, s ssh.Session, exitErr error) {
+	msg := strings.TrimPrefix(exitErr.Error(), "exec: ")
 	if _, err := s.Stderr().Write([]byte(msg)); err != nil {
 		logger.WithError(err).Errorf("failed to write error back to session")
 	}
 
-	if err := s.Exit(getExitStatusFromError(err)); err != nil {
+	if err := s.Exit(getExitStatusFromError(exitErr)); err != nil {
 		logger.WithError(err).Errorf("pty session failed to exit")
 	}
 }
@@ -272,7 +272,7 @@ func getExitStatusFromError(err error) int {
 		return 0
 	}
 
-	var exitErr exec.ExitError
+	var exitErr *exec.ExitError
 	if ok := errors.As(err, &exitErr); !ok {
 		return 1
 	}


### PR DESCRIPTION
Fix the panic when sshd exec with error:

```
panic: errors.As: *target must be interface or implement error, found *exec.ExitError

goroutine 65 [running]:
github.com/cockroachdb/errors/errutil.As({0x9dea60, 0xc000387860}, {0x90a780, 0xc0003878a0?})
	/home/runner/go/pkg/mod/github.com/cockroachdb/errors@v1.11.3/errutil/as.go:49 +0x547
github.com/cockroachdb/errors.As(...)
	/home/runner/go/pkg/mod/github.com/cockroachdb/errors@v1.11.3/errutil_api.go:194
github.com/tensorchord/envd/pkg/remote/sshd.getExitStatusFromError({0x9dea60, 0xc000387860})
	/home/runner/work/envd/envd/pkg/remote/sshd/sshd.go:276 +0x59
github.com/tensorchord/envd/pkg/remote/sshd.sendErrAndExit(0xc0001f2070, {0x9e6ed8, 0xc0003ca1a0}, {0x9dea60, 0xc000387860})
	/home/runner/work/envd/envd/pkg/remote/sshd/sshd.go:265 +0x24e
github.com/tensorchord/envd/pkg/remote/sshd.(*Server).connectionHandler(0xc000134f40, {0x9e6ed8, 0xc0003ca1a0})
	/home/runner/work/envd/envd/pkg/remote/sshd/sshd.go:191 +0xaec
github.com/gliderlabs/ssh.(*session).handleRequests.func1()
	/home/runner/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.8/session.go:261 +0x27
created by github.com/gliderlabs/ssh.(*session).handleRequests in goroutine 42
	/home/runner/go/pkg/mod/github.com/gliderlabs/ssh@v0.3.8/session.go:260 +0x4c7
```

cc @gaocegege 