### PR TITLE
chore: update the code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 *             @kemingy @VoVAllen @gaocegege
 
-*.go          @aseaday @zwpaper
-go.*          @gaocegege
+*.go          @kemingy
+go.*          @kemingy
 
-*.py          @VoVAllen @kemingy
+*.py          @kemingy
 
 base-images/  @gaocegege


### PR DESCRIPTION
This project has been in maintenance status for a long time. Some small updates (to fix the breaking changes introduced by bumping the dependency version) automatically invite several people to review, which is usually unnecessary.

We really appreciate their past contributions. 

**This doesn't change any permissions, only for the automatically generated PR review invitation.** 

We'll still manually invite them to review the code when it's necessary.