### PR TITLE
chore: update goreleaser docker config, use macos-15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, ubuntu-22.04]
+        os: [macos-15, ubuntu-22.04]
     steps:
       - uses: actions/checkout@v5
       - name: Get gobin
@@ -69,7 +69,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.2.1
         env:
           CIBW_ARCHS_MACOS: arm64, x86_64
           CIBW_ARCHS_LINUX: auto64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,8 +42,8 @@ builds:
       - -X github.com/tensorchord/envd/pkg/version.gitTreeState=clean
 archives:
   - id: envd
-    format: binary
-    builds:
+    formats: ["binary"]
+    ids:
       - envd
     name_template: >-
       {{ .Binary }}_{{ .Version }}_
@@ -52,8 +52,8 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
   - id: envd-sshd
-    format: binary
-    builds:
+    formats: ["binary"]
+    ids:
       - envd-sshd
     name_template: >-
       {{ .Binary }}_{{ .Version }}_
@@ -83,47 +83,24 @@ changelog:
       order: 3
     - title: 'Others:'
       order: 999
-dockers:
-- image_templates:
-  - "tensorchord/envd-from-scratch:v{{ .Version }}-amd64"
-  use: buildx
+dockers_v2:
+- id: "envd"
+  images:
+  - "tensorchord/envd-from-scratch"
   dockerfile: base-images/envd/envd.Dockerfile
-  ids:
-  - envd
-  build_flag_templates:
-  - "--platform=linux/amd64"
-- image_templates:
-  - "tensorchord/envd-from-scratch:v{{ .Version }}-arm64v8"
-  use: buildx
-  goarch: arm64
-  ids:
-  - envd
-  dockerfile: base-images/envd/envd.Dockerfile
-  build_flag_templates:
-  - "--platform=linux/arm64/v8"
-- image_templates:
-  - "tensorchord/envd-sshd-from-scratch:v{{ .Version }}-amd64"
-  use: buildx
+  ids: ["envd"]
+  tags:
+  - "v{{ .Version }}"
+  platforms:
+  - linux/amd64
+  - linux/arm64/v8
+- id: "envd-sshd"
+  images:
+  - "tensorchord/envd-sshd-from-scratch"
   dockerfile: base-images/envd-sshd/envd-sshd.Dockerfile
-  ids:
-  - envd-sshd
-  build_flag_templates:
-  - "--platform=linux/amd64"
-- image_templates:
-  - "tensorchord/envd-sshd-from-scratch:v{{ .Version }}-arm64v8"
-  use: buildx
-  goarch: arm64
-  ids:
-  - envd-sshd
-  dockerfile: base-images/envd-sshd/envd-sshd.Dockerfile
-  build_flag_templates:
-  - "--platform=linux/arm64/v8"
-docker_manifests:
-- name_template: tensorchord/envd-sshd-from-scratch:v{{ .Version }}
-  image_templates:
-  - tensorchord/envd-sshd-from-scratch:v{{ .Version }}-amd64
-  - tensorchord/envd-sshd-from-scratch:v{{ .Version }}-arm64v8
-- name_template: tensorchord/envd-from-scratch:v{{ .Version }}
-  image_templates:
-  - tensorchord/envd-from-scratch:v{{ .Version }}-amd64
-  - tensorchord/envd-from-scratch:v{{ .Version }}-arm64v8
+  ids: ["envd-sshd"]
+  tags:
+  - "v{{ .Version }}"
+  platforms:
+  - linux/amd64
+  - linux/arm64/v8

--- a/base-images/envd-sshd/envd-sshd.Dockerfile
+++ b/base-images/envd-sshd/envd-sshd.Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
-COPY envd-sshd /usr/bin/envd-sshd
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/envd-sshd /usr/bin/envd-sshd

--- a/base-images/envd/envd.Dockerfile
+++ b/base-images/envd/envd.Dockerfile
@@ -1,2 +1,3 @@
 FROM scratch
-COPY envd /usr/bin/envd
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/envd /usr/bin/envd


### PR DESCRIPTION
- `macos-13` is deprecated, the OS version is too old

errors:

```txt
   + delocate-wheel --require-archs arm64 -w /private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/cibw-run-9xr8abrv/cp38-macosx_arm64/repaired_wheel -v /private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/cibw-run-9xr8abrv/cp38-macosx_arm64/built_wheel/envd-1.2.2-py2.py3-none-macosx_11_0_arm64.whl
  Fixing: /private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/cibw-run-9xr8abrv/cp38-macosx_arm64/built_wheel/envd-1.2.2-py2.py3-none-macosx_11_0_arm64.whl
  Traceback (most recent call last):
    File "/private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/cibw-run-9xr8abrv/cp38-macosx_arm64/build/venv/bin/delocate-wheel", line 8, in <module>
      sys.exit(main())
    File "/private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/cibw-run-9xr8abrv/cp38-macosx_arm64/build/venv/lib/python3.8/site-packages/delocate/cmd/delocate_wheel.py", line 116, in main
      copied = delocate_wheel(
    File "/private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/cibw-run-9xr8abrv/cp38-macosx_arm64/build/venv/lib/python3.8/site-packages/delocate/delocating.py", line 1090, in delocate_wheel
      out_wheel_fixed = _check_and_update_wheel_name(
    File "/private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/cibw-run-9xr8abrv/cp38-macosx_arm64/build/venv/lib/python3.8/site-packages/delocate/delocating.py", line 925, in _check_and_update_wheel_name
      raise DelocationError(
  delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 11.0:
  /private/var/folders/vk/nx37ffx50hv5djclhltc26vw0000gn/T/tmpy4zsyild/wheel/envd-1.2.2.data/data/bin/envd has a minimum target of 12.0
  Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=12.0' to update minimum supported macOS for this wheel.
```

- update the goreleaser config for docker
- bump cibuildwheel version