### PR TITLE
chore: fix goreleaser docker build cannot find the binary file

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -93,7 +93,7 @@ dockers_v2:
   - "v{{ .Version }}"
   platforms:
   - linux/amd64
-  - linux/arm64/v8
+  - linux/arm64
 - id: "envd-sshd"
   images:
   - "tensorchord/envd-sshd-from-scratch"
@@ -103,4 +103,4 @@ dockers_v2:
   - "v{{ .Version }}"
   platforms:
   - linux/amd64
-  - linux/arm64/v8
+  - linux/arm64


### PR DESCRIPTION
`linux/arm64/v8` & `linux/arm64` are identical.

Fix the docker build cannot found the binary file.

Verified in https://github.com/kemingy/envd/actions/runs/19030137262/job/54341880079