### PR TITLE
chore: align the macOS minimal target version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           CIBW_ARCHS_MACOS: arm64, x86_64
           CIBW_ARCHS_LINUX: auto64
           CIBW_SKIP: pp*
+          MACOSX_DEPLOYMENT_TARGET: 14.0
       - name: Build source distribution
         if: runner.os == 'Linux' # Only release source under linux to avoid conflict
         run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ universal_binaries:
 builds:
   - env:
       - CGO_ENABLED=0
+      - MACOSX_DEPLOYMENT_TARGET=14.0
     goos:
       - linux
       - darwin


### PR DESCRIPTION
cibuildwheel requires an explicit macOS version if the binary is built with something larger than that.

- ref https://github.com/pypa/cibuildwheel/blob/main/docs/platforms.md#macos-version-compatibility
- errors: https://github.com/tensorchord/envd/actions/runs/19030401935/job/54343293158

```
Repairing wheel...
  
  + delocate-wheel --require-archs x86_64 -w /private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cibw-run-l7v7cf_b/cp38-macosx_x86_64/repaired_wheel -v /private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cibw-run-l7v7cf_b/cp38-macosx_x86_64/built_wheel/envd-1.2.5-py2.py3-none-macosx_10_9_x86_64.whl
  Fixing: /private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cibw-run-l7v7cf_b/cp38-macosx_x86_64/built_wheel/envd-1.2.5-py2.py3-none-macosx_10_9_x86_64.whl
  Traceback (most recent call last):
    File "/private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cibw-run-l7v7cf_b/cp38-macosx_x86_64/build/venv/bin/delocate-wheel", line 8, in <module>
      sys.exit(main())
    File "/private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cibw-run-l7v7cf_b/cp38-macosx_x86_64/build/venv/lib/python3.8/site-packages/delocate/cmd/delocate_wheel.py", line 116, in main
      copied = delocate_wheel(
    File "/private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cibw-run-l7v7cf_b/cp38-macosx_x86_64/build/venv/lib/python3.8/site-packages/delocate/delocating.py", line 1090, in delocate_wheel
      out_wheel_fixed = _check_and_update_wheel_name(
    File "/private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/cibw-run-l7v7cf_b/cp38-macosx_x86_64/build/venv/lib/python3.8/site-packages/delocate/delocating.py", line 925, in _check_and_update_wheel_name
      raise DelocationError(
  delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.9:
  /private/var/folders/xc/cl1fyykn2pj4ryhdw6r1mqtc0000gn/T/tmps36ytsq2/wheel/envd-1.2.5.data/data/bin/envd has a minimum target of 12.0
  Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=12.0' to update minimum supported macOS for this wheel.
```