### PR TITLE
feat: add codex template

### DIFF
--- a/pkg/app/template/codex.envd
+++ b/pkg/app/template/codex.envd
@@ -1,0 +1,10 @@
+# This assumes the user already login and save the credentials in the default `~/.codex` directory.
+# If not, you can login first with the command `codex login`.
+
+def build():
+    base(dev=True)
+    shell("fish")
+    install.codex()
+    install.rust()
+    install.uv()
+    runtime.mount("~/.codex", "~/.codex")

--- a/pkg/lang/ir/v1/agent.go
+++ b/pkg/lang/ir/v1/agent.go
@@ -16,7 +16,6 @@ package v1
 
 import (
 	"github.com/moby/buildkit/client/llb"
-	"github.com/sirupsen/logrus"
 
 	"github.com/tensorchord/envd/pkg/lang/ir"
 )
@@ -26,21 +25,16 @@ const (
 )
 
 func (g generalGraph) installAgentCodex(root llb.State, agent ir.CodeAgent) llb.State {
-	if g.Image == defaultImage {
-		// codex requires glibc >= 2.39
-		logrus.Warn("The default image may not support codex properly. Please use a custom base image with glibc >= 2.39")
-	}
-
 	base := llb.Image(builderImage)
 	version := codexDefaultVersion
 	if agent.Version != nil {
 		version = *agent.Version
 	}
 	builder := base.Run(
-		llb.Shlexf(`sh -c "wget -qO- https://github.com/openai/codex/releases/download/rust-v%s/codex-$(uname -m)-unknown-linux-gnu.tar.gz | tar -xz -C /tmp || exit 1"`, version),
+		llb.Shlexf(`sh -c "wget -qO- https://github.com/openai/codex/releases/download/rust-v%s/codex-$(uname -m)-unknown-linux-musl.tar.gz | tar -xz -C /tmp || exit 1"`, version),
 		llb.WithCustomNamef("[internal] download codex %s", version),
 	).Run(
-		llb.Shlex(`sh -c "mv /tmp/codex-$(uname -m)-unknown-linux-gnu /tmp/codex"`),
+		llb.Shlex(`sh -c "mv /tmp/codex-$(uname -m)-unknown-linux-musl /tmp/codex"`),
 		llb.WithCustomNamef("[internal] prepare codex %s", version),
 	).Root()
 	root = root.File(

--- a/pkg/lang/ir/v1/compile.go
+++ b/pkg/lang/ir/v1/compile.go
@@ -390,7 +390,7 @@ func (g *generalGraph) CompileLLB(uid, gid int) (llb.State, error) {
 		}
 		prompt := g.compilePrompt(shell)
 		if g.UVConfig != nil {
-			// re-install uv Python for dev user
+			// install uv Python for dev user
 			prompt = g.compileUVPython(prompt)
 		}
 		entrypoint, err := g.compileEntrypoint(prompt)

--- a/pkg/lang/ir/v1/uv.go
+++ b/pkg/lang/ir/v1/uv.go
@@ -37,6 +37,11 @@ func (g generalGraph) compileUV(root llb.State) llb.State {
 	root = root.File(
 		llb.Copy(builder, "/tmp/uv", "/usr/bin/uv"), llb.WithCustomName("[internal] install uv")).
 		File(llb.Copy(builder, "/tmp/uvx", "/usr/bin/uvx"), llb.WithCustomName("[internal] install uvx"))
+
+	if g.Dev {
+		// skip install uv Python for sudo when `dev=True`
+		return root
+	}
 	return g.compileUVPython(root)
 }
 

--- a/pkg/types/envd.go
+++ b/pkg/types/envd.go
@@ -61,8 +61,8 @@ var BaseEnvironment = []struct {
 }
 var BaseAptPackage = []string{
 	"bash-static",
-	"libtinfo5",
-	"libncursesw5",
+	"'libtinfo[56]'",
+	"'libncursesw[56]'",
 	// conda dependencies
 	"bzip2",
 	"ca-certificates",


### PR DESCRIPTION
- add `codex.envd` template, try it with `envd new -t codex`
- change codex from gnu to musl to avoid the glibc version requirements
- only install the uv python once when `dev=True`
- use apt glob syntax to avoid "Unable to locate package libtinfo5" on Ubuntu 24:04