### PR TITLE
feat: push to ghcr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -17,11 +20,17 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: 'stable'
-      - name: Login to Docker
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run GoReleaser
@@ -114,6 +123,9 @@ jobs:
     if: github.repository == 'tensorchord/envd' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs: goreleaser
+    permissions:
+      contents: read
+      packages: write
     steps:
     - uses: actions/checkout@v5
     - name: Set up Docker Buildx
@@ -126,11 +138,12 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
-    - name: Docker Login
+    - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERIO_USERNAME }}
-        password: ${{ secrets.DOCKERIO_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Docker Buildx
       run: |
           ./base-images/envd/build.sh
@@ -139,14 +152,15 @@ jobs:
     # only trigger on main repo when tag starts with v
     if: github.repository == 'tensorchord/envd' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
         include:
           - build_func: build
             tag_suffix: ""
-          - build_func: build_gpu_11_8
-            tag_suffix: "-cuda-11.8.0-cudnn-8"
     needs: goreleaser
     steps:
     - uses: actions/checkout@v5
@@ -170,11 +184,12 @@ jobs:
       run: |
         mv dist/envd_linux_amd64_v1/envd /usr/local/bin/envd
         chmod +x /usr/local/bin/envd
-    - name: Docker Login
+    - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERIO_USERNAME }}
-        password: ${{ secrets.DOCKERIO_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and push
       run: ./base-images/remote-cache/build-and-push-remote-cache.sh
       env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,21 +47,13 @@ archives:
     ids:
       - envd
     name_template: >-
-      {{ .Binary }}_{{ .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
   - id: envd-sshd
     formats: ["binary"]
     ids:
       - envd-sshd
     name_template: >-
-      {{ .Binary }}_{{ .Version }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -88,6 +80,7 @@ dockers_v2:
 - id: "envd"
   images:
   - "tensorchord/envd-from-scratch"
+  - "ghcr.io/tensorchord/envd-from-scratch"
   dockerfile: base-images/envd/envd.Dockerfile
   ids: ["envd"]
   tags:
@@ -98,6 +91,7 @@ dockers_v2:
 - id: "envd-sshd"
   images:
   - "tensorchord/envd-sshd-from-scratch"
+  - "ghcr.io/tensorchord/envd-sshd-from-scratch"
   dockerfile: base-images/envd-sshd/envd-sshd.Dockerfile
   ids: ["envd-sshd"]
   tags:

--- a/base-images/envd/build.sh
+++ b/base-images/envd/build.sh
@@ -20,7 +20,7 @@ ROOT_DIR=`dirname $0`
 
 GIT_TAG_VERSION=$(git describe --tags --abbrev=0)
 ENVD_VERSION="${ENVD_VERSION:-$GIT_TAG_VERSION}"
-DOCKER_HUB_ORG="${DOCKER_HUB_ORG:-tensorchord}"
+DOCKER_HUB_ORG="${DOCKER_HUB_ORG:-ghcr.io/tensorchord}"
 TAG_SUFFIX="${TAG_SUFFIX:-}"
 
 cd ${ROOT_DIR}
@@ -28,7 +28,7 @@ cd ${ROOT_DIR}
 docker buildx build \
     --build-arg ENVD_VERSION=${ENVD_VERSION} \
     -t ${DOCKER_HUB_ORG}/envd:${ENVD_VERSION}-rootless \
-    --pull --push --platform linux/x86_64,linux/arm64 \
+    --pull --push --platform linux/amd64,linux/arm64 \
     -f envd-daemonless.Dockerfile ../../
 
 cd - > /dev/null

--- a/base-images/envd/envd-daemonless.Dockerfile
+++ b/base-images/envd/envd-daemonless.Dockerfile
@@ -1,6 +1,6 @@
 ARG ENVD_VERSION
 
-FROM tensorchord/envd-from-scratch:${ENVD_VERSION} as envd
+FROM ghcr.io/tensorchord/envd-from-scratch:${ENVD_VERSION} as envd
 
 FROM moby/buildkit:v0.25.1-rootless
 COPY --from=envd /usr/bin/envd /usr/bin/envd

--- a/base-images/remote-cache/build-and-push-remote-cache.sh
+++ b/base-images/remote-cache/build-and-push-remote-cache.sh
@@ -27,6 +27,6 @@ TAG_SUFFIX="${TAG_SUFFIX:-}"
 cd ${ROOT_DIR}
 
 envd context create --name docker --builder docker-container --use
-envd --debug build -f build.envd:${BUILD_FUNC} --export-cache type=registry,ref=docker.io/${DOCKER_HUB_ORG}/python-cache:envd-v${ENVD_VERSION}${TAG_SUFFIX} --force
+envd --debug build -f build.envd:${BUILD_FUNC} --export-cache type=registry,ref=ghcr.io/${DOCKER_HUB_ORG}/python-cache:envd-v${ENVD_VERSION}${TAG_SUFFIX} --force
 
 cd - > /dev/null


### PR DESCRIPTION
- part of #1959 
- push envd & envd-sshd to both docker hub & ghcr
- push envd-daemonless & envd-python-cache to ghcr instead of docker hub

---

- change the release artifacts naming template
- fix envd-daemonless build platform target name